### PR TITLE
Automate release and close process on Nexus

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
           java-version: 1.8
 
       - name: Publish to the Maven Central Repository
-        run: ./gradlew clean removeSnapshot uploadArchives --no-daemon --no-parallel
+        run: ./gradlew clean removeSnapshot uploadArchives closeAndReleaseRepository --no-daemon --no-parallel
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:50:49Z" title="Tuesday, July 7th 2020, 3:50:49 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:56:53Z" title="Tuesday, July 7th 2020, 3:56:53 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-11T03:58:17Z" title="Thursday, June 11th 2020, 1:58:17 pm +10:00">Jun 11, 2020</time>_
_Merged <time datetime="2020-06-11T04:49:09Z" title="Thursday, June 11th 2020, 2:49:09 pm +10:00">Jun 11, 2020</time>_
---

## Summary of Changes

- Automate release and close process on Nexus Repository Manager.

## Items of Note

This should remove the last manual part of the release process.