### PR TITLE
 Open external links in default browser

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/view/WebCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/WebCheckoutActivity.kt
@@ -41,11 +41,7 @@ internal class WebCheckoutActivity : AppCompatActivity() {
     }
 
     private fun finish(status: CheckoutStatus) {
-        if (status == CheckoutStatus.CANCELLED) {
-            setResult(Activity.RESULT_CANCELED)
-        } else {
-            setResult(Activity.RESULT_OK, Intent().putCheckoutStatusExtra(status))
-        }
+        setResult(status.resultCode, Intent().putCheckoutStatusExtra(status))
         finish()
     }
 }
@@ -65,3 +61,6 @@ private class AfterpayWebViewClient(
         return true
     }
 }
+
+private val CheckoutStatus.resultCode: Int
+    get() = if (this == CheckoutStatus.CANCELLED) Activity.RESULT_CANCELED else Activity.RESULT_OK


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:50:54Z" title="Tuesday, July 7th 2020, 3:50:54 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:56:57Z" title="Tuesday, July 7th 2020, 3:56:57 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-16T06:10:23Z" title="Tuesday, June 16th 2020, 4:10:23 pm +10:00">Jun 16, 2020</time>_
_Merged <time datetime="2020-06-16T06:41:37Z" title="Tuesday, June 16th 2020, 4:41:37 pm +10:00">Jun 16, 2020</time>_
---

During the checkout process, external links can be accessed such as the terms and conditions, and the privacy policy. These should be opened outside of the web view as they can lead the user out of the checkout portal and to the Afterpay website.

## Summary of Changes

- Open non-merchant redirect URLs in the default browser instead of the WebView.