### PR TITLE
Fix web checkout activity memory leak

### DIFF
--- a/afterpay/src/main/res/layout/activity_web_checkout.xml
+++ b/afterpay/src/main/res/layout/activity_web_checkout.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/afterpay_webView_container"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent">
+
+    <WebView
+        android:id="@+id/afterpay_webView"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent" />
+
+</FrameLayout>


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:51:12Z" title="Tuesday, July 7th 2020, 3:51:12 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:57:13Z" title="Tuesday, July 7th 2020, 3:57:13 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-18T23:33:54Z" title="Friday, June 19th 2020, 9:33:54 am +10:00">Jun 19, 2020</time>_
_Merged <time datetime="2020-06-19T05:30:26Z" title="Friday, June 19th 2020, 3:30:26 pm +10:00">Jun 19, 2020</time>_
---

The WebView was causing a memory leak when the activity was destroyed, as diagnosed by the `StrictMode.VMPolicy` monitoring for Activity leaks in the example app.

To prevent this leak, the WebView is now manually stopped from loading, removed from the view hierarchy and destroyed when the Activity is destroyed.

## Summary of Changes

- Manually cleanup `WebView` before the `WebCheckoutActivity` is destroyed.