### PR TITLE
Capture web checkout errors

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/view/WebCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/WebCheckoutActivity.kt
@@ -5,11 +5,13 @@ import android.app.Activity
 import android.content.Intent
 import android.net.Uri
 import android.os.Bundle
+import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebResourceRequest
 import android.webkit.WebResourceResponse
 import android.webkit.WebView
 import android.webkit.WebViewClient
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import com.afterpay.android.R
 import com.afterpay.android.util.getCheckoutUrlExtra
@@ -17,6 +19,7 @@ import com.afterpay.android.util.putOrderTokenExtra
 
 internal class WebCheckoutActivity : AppCompatActivity() {
     private lateinit var webView: WebView
+    private lateinit var errorTextView: TextView
 
     @SuppressLint("SetJavaScriptEnabled")
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -27,11 +30,12 @@ internal class WebCheckoutActivity : AppCompatActivity() {
 
         val checkoutUrl = requireNotNull(intent.getCheckoutUrlExtra()) { "Checkout URL is missing" }
 
+        errorTextView = findViewById(R.id.afterpay_errorMessage)
         webView = findViewById<WebView>(R.id.afterpay_webView).apply {
             settings.javaScriptEnabled = true
             webViewClient = AfterpayWebViewClient(
                 openExternalLink = ::open,
-                receivedError = {},
+                receivedError = ::receivedError,
                 completed = ::finish
             )
             loadUrl(checkoutUrl)
@@ -54,6 +58,11 @@ internal class WebCheckoutActivity : AppCompatActivity() {
         if (intent.resolveActivity(packageManager) != null) {
             startActivity(intent)
         }
+    }
+
+    private fun receivedError() {
+        errorTextView.visibility = View.VISIBLE
+        webView.visibility = View.GONE
     }
 
     private fun finish(status: CheckoutStatus) {

--- a/afterpay/src/main/res/layout/activity_web_checkout.xml
+++ b/afterpay/src/main/res/layout/activity_web_checkout.xml
@@ -2,11 +2,21 @@
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
     android:id="@+id/afterpay_webView_container"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    android:background="@android:color/background_light">
 
     <WebView
         android:id="@+id/afterpay_webView"
         android:layout_width="match_parent"
         android:layout_height="match_parent" />
+
+    <TextView
+        android:id="@+id/afterpay_errorMessage"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="@string/web_checkout_error_message"
+        android:textColor="@android:color/primary_text_light"
+        android:visibility="gone" />
 
 </FrameLayout>

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <string name="web_checkout_error_message">An error occurred during checkout</string>
+</resources>


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:51:14Z" title="Tuesday, July 7th 2020, 3:51:14 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:57:16Z" title="Tuesday, July 7th 2020, 3:57:16 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-18T23:58:38Z" title="Friday, June 19th 2020, 9:58:38 am +10:00">Jun 19, 2020</time>_
_Closed <time datetime="2020-06-21T23:52:42Z" title="Monday, June 22nd 2020, 9:52:42 am +10:00">Jun 22, 2020</time>_
---

## Summary of Changes

- Capture web view loading errors and display an error message when they occur.

## Items of Note

This displays a very primitive error message and there is no retry functionality, but that will come in a future PR.

![WebView Load Error](https://user-images.githubusercontent.com/5798516/85082974-ba6c3d80-b213-11ea-9b0a-7a033e1bfae7.gif)
