### PR TITLE
Define INTERNET permission in SDK manifest

### DIFF
--- a/afterpay/src/main/AndroidManifest.xml
+++ b/afterpay/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.afterpay.android">
 
+    <uses-permission android:name="android.permission.INTERNET" />
+
     <application>
         <activity
             android:name=".view.WebCheckoutActivity"

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -3,8 +3,6 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="com.example.afterpay">
 
-    <uses-permission android:name="android.permission.INTERNET" />
-
     <application
         android:name=".ExampleApplication"
         android:allowBackup="true"


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:51:17Z" title="Tuesday, July 7th 2020, 3:51:17 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:57:18Z" title="Tuesday, July 7th 2020, 3:57:18 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-22T00:36:18Z" title="Monday, June 22nd 2020, 10:36:18 am +10:00">Jun 22, 2020</time>_
_Merged <time datetime="2020-06-22T00:51:14Z" title="Monday, June 22nd 2020, 10:51:14 am +10:00">Jun 22, 2020</time>_
---

The SDK requires the `INTERNET` permission to operate so this should be included in its manifest, instead of requiring the consuming app to define it.

## Summary of Changes

- Move `INTERNET` permission from example app to SDK manifest.