### PR TITLE
Enable dark theme support in example app and SDK

### DIFF
--- a/afterpay/src/main/res/values/styles.xml
+++ b/afterpay/src/main/res/values/styles.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <style name="AfterpayDialog" parent="Theme.AppCompat.Dialog">
+    <style name="AfterpayDialog" parent="Theme.AppCompat.DayNight.Dialog">
         <item name="windowActionBar">false</item>
         <item name="windowNoTitle">true</item>
         <item name="android:windowIsFloating">true</item>

--- a/example/src/main/res/values/styles.xml
+++ b/example/src/main/res/values/styles.xml
@@ -1,6 +1,6 @@
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.Light.DarkActionBar">
+    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
         <!-- Customize your theme here. -->
         <item name="colorPrimary">@color/colorPrimary</item>
         <item name="colorPrimaryDark">@color/colorPrimaryDark</item>


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:51:19Z" title="Tuesday, July 7th 2020, 3:51:19 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:57:20Z" title="Tuesday, July 7th 2020, 3:57:20 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-22T01:16:49Z" title="Monday, June 22nd 2020, 11:16:49 am +10:00">Jun 22, 2020</time>_
_Merged <time datetime="2020-06-22T01:51:31Z" title="Monday, June 22nd 2020, 11:51:31 am +10:00">Jun 22, 2020</time>_
---

## Summary of Changes

- Support dark theme in SDK and example app.

## Items of Note

The SDK will continue to use a light background for the WebVew to avoid a jarring experience when loading the Afterpay checkout portal.