### PR TITLE
Expose Afterpay SDK as static methods for Java

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -16,7 +16,7 @@ object Afterpay {
      * @param checkoutUrl The URL used to initiate the transaction.
      * @return An intent to initiate the Afterpay transaction.
      */
-    fun createCheckoutIntent(context: Context, checkoutUrl: String): Intent =
+    @JvmStatic fun createCheckoutIntent(context: Context, checkoutUrl: String): Intent =
         Intent(context, WebCheckoutActivity::class.java)
             .putCheckoutUrlExtra(checkoutUrl)
 
@@ -27,6 +27,6 @@ object Afterpay {
      * [startActivityForResult][android.app.Activity.startActivityForResult].
      * @return The order token associated with the transaction.
      */
-    fun parseCheckoutResponse(intent: Intent): String? =
+    @JvmStatic fun parseCheckoutResponse(intent: Intent): String? =
         intent.getOrderTokenExtra()
 }


### PR DESCRIPTION
> [<img alt="logan-han" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/logan-han) **Authored by [logan-han](https://github.com/logan-han)**
_<time datetime="2020-07-07T05:51:44Z" title="Tuesday, July 7th 2020, 3:51:44 pm +10:00">Jul 7, 2020</time>_
_Closed <time datetime="2020-07-07T05:57:41Z" title="Tuesday, July 7th 2020, 3:57:41 pm +10:00">Jul 7, 2020</time>_
---

> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-06-30T06:25:51Z" title="Tuesday, June 30th 2020, 4:25:51 pm +10:00">Jun 30, 2020</time>_
_Merged <time datetime="2020-07-01T01:16:03Z" title="Wednesday, July 1st 2020, 11:16:03 am +10:00">Jul 1, 2020</time>_
---

When using the SDK in Java, the only way to access the two top level methods exposed by the Afterpay object was through the singleton instance:

    Afterpay.INSTANCE.createCheckoutIntent(this, url)

The `@JvmStatic` annotation ensures that a static method on the Afterpay object is generated. Access to the SDK methods now functions in the same way as designed for Kotlin:

    Afterpay.createCheckoutIntent(this, url)

## Summary of Changes

- Expose top level methods as static to the JVM for using the SDK with Java.