### PR TITLE
Update URLs to reference public repository

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,7 +5,7 @@ appropriately.
 
 Bug fixes and new features should include tests and documentation.
 
-Contributors guide: https://github.com/afterpay/afterpay-android/blob/master/CONTRIBUTING.md
+Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
 -->
 
 ## Summary of Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,7 @@ If the above doesn't help, please [submit an issue][new-issue] via GitHub.
 
 - Click the [Fork][fork-repo] button in the upper right corner of the repository.
 - Clone your fork:
-    `git clone git@github.com:<YOUR_GITHUB_USER>/afterpay-android.git`
+    `git clone git@github.com:<YOUR_GITHUB_USER>/sdk-android.git`
 - See the [GitHub documentation][fork-docs] about managing your fork.
 
 #### Recommended
@@ -63,12 +63,12 @@ All contributions to this project are also under this license as per [GitHub's T
 [code-of-conduct]: CODE_OF_CONDUCT.md
 [code-owners]: .github/CODEOWNERS
 [commit-messages]: https://chris.beams.io/posts/git-commit/
-[fork-repo]: https://github.com/afterpay/afterpay-android/fork
+[fork-repo]: https://github.com/afterpay/sdk-android/fork
 [fork-docs]: https://help.github.com/articles/working-with-forks/
 [github-terms-contribution]: https://help.github.com/en/github/site-policy/github-terms-of-service#6-contributions-under-repository-license
-[issues]: https://github.com/afterpay/afterpay-android/issues
+[issues]: https://github.com/afterpay/sdk-android/issues
 [license]: LICENSE
-[new-issue]: https://github.com/afterpay/afterpay-android/issues/new/choose
+[new-issue]: https://github.com/afterpay/sdk-android/issues/new/choose
 [pr-template]: .github/PULL_REQUEST_TEMPLATE.md
 [pr-docs]: https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/requesting-a-pull-request-review
 [readme]: README.md

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Contributions are welcome! Please read our [contributing guidelines][contributin
 This project is licensed under the terms of the Apache 2.0 license. See the [LICENSE][license] file for more information.
 
 <!-- Links: -->
-[badge-ci]: https://github.com/afterpay/afterpay-android/workflows/Build%20and%20Test/badge.svg?branch=master&event=push
+[badge-ci]: https://github.com/afterpay/sdk-android/workflows/Build%20and%20Test/badge.svg?branch=master&event=push
 [badge-ktlint]: https://img.shields.io/badge/code%20style-%E2%9D%A4-FF4081.svg
 [contributing]: CONTRIBUTING.md
 [example]: example

--- a/example/README.md
+++ b/example/README.md
@@ -43,7 +43,7 @@ The receipt screen displays the transaction token return by the SDK for a succes
 [activity-result]: https://developer.android.com/reference/android/app/Activity#onActivityResult(int,%20int,%20android.content.Intent)
 [kotlin-coroutines]: https://developer.android.com/kotlin/coroutines
 [kotlin-flow]: https://kotlinlang.org/docs/reference/coroutines/flow.html
-[sample-server]: https://github.com/afterpay/afterpay-example-server
-[sample-server-instructions]: https://github.com/afterpay/afterpay-example-server#getting-started
-[sdk-create-checkout]: https://github.com/afterpay/afterpay-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L19
-[sdk-parse-response]: https://github.com/afterpay/afterpay-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L30
+[sample-server]: https://github.com/afterpay/sdk-example-server
+[sample-server-instructions]: https://github.com/afterpay/sdk-example-server#getting-started
+[sdk-create-checkout]: https://github.com/afterpay/sdk-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L19
+[sdk-parse-response]: https://github.com/afterpay/sdk-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L30

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,10 +1,10 @@
 GROUP=com.afterpay
 VERSION_NAME=0.0.2-SNAPSHOT
 
-POM_URL=https://github.com/afterpay/afterpay-android/
-POM_SCM_URL=https://github.com/afterpay/afterpay-android/
-POM_SCM_CONNECTION=scm:git:git://github.com/afterpay/afterpay-android.git
-POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/afterpay/afterpay-android.git
+POM_URL=https://github.com/afterpay/sdk-android/
+POM_SCM_URL=https://github.com/afterpay/sdk-android/
+POM_SCM_CONNECTION=scm:git:git://github.com/afterpay/sdk-android.git
+POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/afterpay/sdk-android.git
 
 POM_LICENCE_NAME=The Apache Software License, Version 2.0
 POM_LICENCE_URL=https://www.apache.org/licenses/LICENSE-2.0.txt


### PR DESCRIPTION
> [<img alt="Rypac" height="40" width="40" align="left" src="https://avatars1.githubusercontent.com/u/38261864?s=88&v=4">](https://github.com/Rypac) **Authored by [Rypac](https://github.com/Rypac)**
_<time datetime="2020-07-14T00:47:48Z" title="Tuesday, July 14th 2020, 10:47:48 am +10:00">Jul 14, 2020</time>_

---

## Summary of Changes

- Change GitHub URLs to reference [public Afterpay organisation](https://github.com/afterpay).

## Items of Note

We can hold off merging this until the migration is complete.