### PR TITLE
Display dialog for web view loading errors

### DIFF
--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+
+    <string name="load_error_title">Error</string>
+    <string name="load_error_message">Failed to load Afterpay checkout</string>
+    <string name="load_error_retry">Retry</string>
+    <string name="load_error_cancel">Cancel</string>
+
+</resources>


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Display dialog for web view loading errors. The dialog presents the option to retry loading the checkout URL or to cancel the Afterpay web checkout.

## Items of Note

The copy in the dialog will need some work but it is currently functionally complete.