### PR TITLE
Use updated gradle task for releasing to Maven

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -29,7 +29,7 @@ jobs:
           ORG_GRADLE_PROJECT_signingPassword: ${{ secrets.PGP_SIGNING_PASSWORD }}
 
       - name: Publish release to the Maven Central Repository
-        run: ./gradlew afterpay:closeAndReleaseRepository
+        run: ./gradlew closeAndReleaseRepository
         env:
           SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}


### PR DESCRIPTION
## Summary of Changes

- Use updated gradle task for releasing to Maven.

## Items of Note

A single release task is now generated instead of one per project.