### PR TITLE
Disable minification of the SDK and remove unneeded proguard rules

### DIFF
--- a/afterpay/build.gradle
+++ b/afterpay/build.gradle
@@ -26,13 +26,6 @@ android {
     kotlinOptions {
         jvmTarget = versions.java
     }
-
-    buildTypes {
-        release {
-            minifyEnabled true
-            proguardFiles getDefaultProguardFile('proguard-android-optimize.txt'), 'proguard-rules.pro'
-        }
-    }
 }
 
 dependencies {

--- a/afterpay/consumer-rules.pro
+++ b/afterpay/consumer-rules.pro
@@ -1,2 +1,0 @@
--keep class com.afterpay.android.** { *; }
--dontwarn com.afterpay.android.**

--- a/afterpay/consumer-rules.pro
+++ b/afterpay/consumer-rules.pro
@@ -1,0 +1,2 @@
+-keep class com.afterpay.android.** { *; }
+-dontwarn com.afterpay.android.**

--- a/afterpay/proguard-rules.pro
+++ b/afterpay/proguard-rules.pro
@@ -1,2 +1,0 @@
--keep class com.afterpay.android.Afterpay { *; }
--keep class com.afterpay.android.CancellationStatus { *; }


### PR DESCRIPTION
## Summary of Changes

- Disable minify and proguard for SDK release builds
- Remove unneeded proguard rules.

## Items of Note

It seems the proguard was causing issues with documentation in the IDE. After some research it seems libraries should only provide proguard rules and it's the responsibility of the application to enable proguard for release builds.