### PR TITLE
Add Afterpay portal certificate pinning in the example application

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The Afterpay Android SDK makes it quick and easy to provide an excellent payment
     - [Proguard](#proguard)
 - [Features](#features)
 - [Getting Started](#getting-started)
+- [Security](#security)
 - [Examples](#examples)
 - [Contributing](#contributing)
 - [License](#license)
@@ -78,6 +79,26 @@ class ExampleActivity: Activity {
 }
 ```
 
+## Security
+
+To limit the possibility of a man-in-the-middle attack during the checkout process, certificate pinning can be configured for the Afterpay portal. Please refer to the Android [Network Security Configuration][network-config] documentation for more information.
+
+Add the following configuration to your `res/xml/network_security_configuration.xml` to enforce certificate pinning for the Afterpay portal.
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <domain-config cleartextTrafficPermitted="false">
+        <domain>portal.afterpay.com</domain>
+        <pin-set expiration="2022-05-25">
+            <pin digest="SHA-256">nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI=</pin>
+        </pin-set>
+    </domain-config>
+</network-security-config>
+```
+
+> **NOTE:** It is necessary to keep the certificate PINs updated to ensure pinning will not be bypassed beyond the expiry date of the certificate.
+
 ## Examples
 
 The [example project][example] demonstrates how to include an Afterpay payment flow using our prebuilt UI components.
@@ -97,4 +118,5 @@ This project is licensed under the terms of the Apache 2.0 license. See the [LIC
 [example]: example
 [ktlint]: https://ktlint.github.io
 [license]: LICENSE
+[network-config]: https://developer.android.com/training/articles/security-config#CertificatePinning
 [proguard-rules]: afterpay/proguard-rules.pro

--- a/example/src/main/AndroidManifest.xml
+++ b/example/src/main/AndroidManifest.xml
@@ -9,6 +9,7 @@
         android:fullBackupContent="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/Theme.Afterpay.DayNight"

--- a/example/src/main/res/xml/network_security_config.xml
+++ b/example/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config xmlns:tools="http://schemas.android.com/tools">
+    <!-- This is the default base configuration for all applications targeting Android 9 (API level 28) or above. -->
+    <base-config cleartextTrafficPermitted="false">
+        <trust-anchors>
+            <certificates src="system" />
+        </trust-anchors>
+    </base-config>
+
+    <!-- Enable certificate pinning for the Afterpay portal. This should be included in network_security_config of your application. -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">portal.afterpay.com</domain>
+        <pin-set
+            expiration="2022-05-25"
+            tools:ignore="MissingBackupPin">
+            <pin digest="SHA-256">nQ1Tu17lpJ/Hsr3545eCkig+X9ZPcxRQoe5WMSyyqJI=</pin>
+        </pin-set>
+    </domain-config>
+
+    <!-- The following configuration is only required for the example application. -->
+
+    <!-- Enable certificate pinning for the Afterpay sandbox portal. -->
+    <domain-config cleartextTrafficPermitted="false">
+        <domain includeSubdomains="false">portal.sandbox.afterpay.com</domain>
+        <pin-set
+            expiration="2021-07-05"
+            tools:ignore="MissingBackupPin">
+            <pin digest="SHA-256">15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4=</pin>
+        </pin-set>
+    </domain-config>
+
+    <!-- For local web server. -->
+    <domain-config cleartextTrafficPermitted="true">
+        <domain includeSubdomains="false">10.0.2.2</domain>
+    </domain-config>
+</network-security-config>


### PR DESCRIPTION
## Summary of Changes

- Add certificate pinning for `portal.afterpay.com` and `portal.sandbox.afterpay.com` in the example application.
- Include documentation for adding certificate pinning in the README.