### PR TITLE
Validate minimum and maximum order amounts

### DIFF
--- a/afterpay/build.gradle
+++ b/afterpay/build.gradle
@@ -16,6 +16,7 @@ android {
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'
+        test.java.srcDirs += 'src/test/kotlin'
     }
 
     compileOptions {
@@ -31,6 +32,7 @@ android {
 dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:${versions.kotlin}"
     implementation "androidx.appcompat:appcompat:${versions.app_compat}"
+    testImplementation "junit:junit:${versions.junit}"
 }
 
 apply plugin: 'com.vanniktech.maven.publish'

--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -9,6 +9,7 @@ import com.afterpay.android.util.putCheckoutUrlExtra
 import com.afterpay.android.view.WebCheckoutActivity
 import java.lang.IllegalArgumentException
 import java.lang.NumberFormatException
+import java.math.BigDecimal
 import java.util.Currency
 
 object Afterpay {
@@ -66,6 +67,15 @@ object Afterpay {
             minimumAmount = minimumAmount?.toBigDecimal(),
             maximumAmount = maximumAmount.toBigDecimal(),
             currency = Currency.getInstance(currencyCode)
-        )
+        ).also { configuration ->
+            if (configuration.maximumAmount < BigDecimal.ZERO) {
+                throw IllegalArgumentException("Maximum order amount is invalid")
+            }
+            configuration.minimumAmount?.let { minimumAmount ->
+                if (minimumAmount < BigDecimal.ZERO || minimumAmount > configuration.maximumAmount) {
+                    throw IllegalArgumentException("Minimum order amount is invalid")
+                }
+            }
+        }
     }
 }

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayTest.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayTest.kt
@@ -1,0 +1,92 @@
+package com.afterpay.android
+
+import org.junit.Assert.assertThrows
+import org.junit.Test
+import java.lang.IllegalArgumentException
+import java.lang.NumberFormatException
+
+class AfterpayTest {
+    @Test
+    fun `setConfiguration does not throw for valid configuration`() {
+        Afterpay.setConfiguration(
+            minimumAmount = "10.00",
+            maximumAmount = "100.00",
+            currencyCode = "AUD"
+        )
+    }
+
+    @Test
+    fun `setConfiguration does not throw for valid configuration with no minimum amount`() {
+        Afterpay.setConfiguration(
+            minimumAmount = null,
+            maximumAmount = "100.00",
+            currencyCode = "AUD"
+        )
+    }
+
+    @Test
+    fun `setConfiguration throws for invalid currency code`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Afterpay.setConfiguration(
+                minimumAmount = "10.00",
+                maximumAmount = "100.00",
+                currencyCode = "foo"
+            )
+        }
+    }
+
+    @Test
+    fun `setConfiguration throws for invalid minimum order amount`() {
+        assertThrows(NumberFormatException::class.java) {
+            Afterpay.setConfiguration(
+                minimumAmount = "foo",
+                maximumAmount = "100.00",
+                currencyCode = "AUD"
+            )
+        }
+    }
+
+    @Test
+    fun `setConfiguration throws for invalid maximum order amount`() {
+        assertThrows(NumberFormatException::class.java) {
+            Afterpay.setConfiguration(
+                minimumAmount = "10.00",
+                maximumAmount = "foo",
+                currencyCode = "AUD"
+            )
+        }
+    }
+
+    @Test
+    fun `setConfiguration throws for minimum order amount less than zero`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Afterpay.setConfiguration(
+                minimumAmount = "-10.00",
+                maximumAmount = "100.00",
+                currencyCode = "AUD"
+            )
+        }
+    }
+
+    @Test
+    fun `setConfiguration throws for minimum order amount greater than maximum amount`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Afterpay.setConfiguration(
+                minimumAmount = "110.00",
+                maximumAmount = "100.00",
+                currencyCode = "AUD"
+            )
+        }
+    }
+
+    @Test
+    fun `setConfiguration throws for maximum order amount less than zero`() {
+        assertThrows(IllegalArgumentException::class.java) {
+            Afterpay.setConfiguration(
+                minimumAmount = null,
+                maximumAmount = "-2.00",
+                currencyCode = "AUD"
+            )
+        }
+    }
+}

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         'moshi': '1.9.3',
         'okhttp': '4.8.0',
         'retrofit': '2.9.0',
+        'junit': '4.13',
         'ktlint': '0.37.2'
     ]
 


### PR DESCRIPTION
## Summary of Changes

- Validate maximum order amount is not less than zero.
- Validate minimum order amount (if present) is not less than zero or greater than the maximum amount.