### PR TITLE
Set SDK configuration in example app

### DIFF
--- a/example/src/main/kotlin/com/example/afterpay/Dependencies.kt
+++ b/example/src/main/kotlin/com/example/afterpay/Dependencies.kt
@@ -1,0 +1,21 @@
+package com.example.afterpay
+
+import com.example.afterpay.data.MerchantApi
+import com.squareup.moshi.Moshi
+import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object Dependencies {
+    val merchantApi: MerchantApi = Retrofit.Builder()
+        .baseUrl("https://10.0.2.2:3001")
+        .addConverterFactory(
+            MoshiConverterFactory.create(
+                Moshi.Builder()
+                    .add(KotlinJsonAdapterFactory())
+                    .build()
+            )
+        )
+        .build()
+        .create(MerchantApi::class.java)
+}

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -17,6 +17,7 @@ import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
 import com.afterpay.android.Afterpay
+import com.example.afterpay.Dependencies
 import com.example.afterpay.R
 import com.example.afterpay.checkout.CheckoutViewModel.Command
 import com.example.afterpay.nav_graph
@@ -31,7 +32,8 @@ class CheckoutFragment : Fragment() {
 
     private val viewModel by viewModels<CheckoutViewModel> {
         CheckoutViewModel.factory(
-            totalCost = requireNotNull(arguments?.get(nav_graph.args.total_cost) as? BigDecimal)
+            totalCost = requireNotNull(arguments?.get(nav_graph.args.total_cost) as? BigDecimal),
+            merchantApi = Dependencies.merchantApi
         )
     }
 
@@ -71,18 +73,11 @@ class CheckoutFragment : Fragment() {
                         val intent = Afterpay.createCheckoutIntent(requireContext(), command.url)
                         startActivityForResult(intent, CHECKOUT_WITH_AFTERPAY)
                     }
-                    is Command.ApplyAfterpayConfiguration -> {
-                        val (minimumAmount, maximumAmount, currency) = command.configuration
-                        Afterpay.setConfiguration(minimumAmount, maximumAmount, currency)
-                    }
                     is Command.DisplayError -> {
                         Snackbar.make(requireView(), command.message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
             }
-        }
-        lifecycleScope.launchWhenStarted {
-            viewModel.fetchConfiguration()
         }
     }
 

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -71,11 +71,18 @@ class CheckoutFragment : Fragment() {
                         val intent = Afterpay.createCheckoutIntent(requireContext(), command.url)
                         startActivityForResult(intent, CHECKOUT_WITH_AFTERPAY)
                     }
+                    is Command.ApplyAfterpayConfiguration -> {
+                        val (minimumAmount, maximumAmount, currency) = command.configuration
+                        Afterpay.setConfiguration(minimumAmount, maximumAmount, currency)
+                    }
                     is Command.DisplayError -> {
                         Snackbar.make(requireView(), command.message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
             }
+        }
+        lifecycleScope.launchWhenStarted {
+            viewModel.fetchConfiguration()
         }
     }
 

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -65,14 +65,14 @@ class CheckoutFragment : Fragment() {
             }
         }
         lifecycleScope.launchWhenStarted {
-            viewModel.commands().collectLatest { event ->
-                when (event) {
+            viewModel.commands().collectLatest { command ->
+                when (command) {
                     is Command.StartAfterpayCheckout -> {
-                        val intent = Afterpay.createCheckoutIntent(requireContext(), event.url)
+                        val intent = Afterpay.createCheckoutIntent(requireContext(), command.url)
                         startActivityForResult(intent, CHECKOUT_WITH_AFTERPAY)
                     }
                     is Command.DisplayError -> {
-                        Snackbar.make(requireView(), event.message, Snackbar.LENGTH_SHORT).show()
+                        Snackbar.make(requireView(), command.message, Snackbar.LENGTH_SHORT).show()
                     }
                 }
             }

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
@@ -3,8 +3,8 @@ package com.example.afterpay.checkout
 import android.util.Patterns
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
+import com.example.afterpay.data.CheckoutRequest
 import com.example.afterpay.data.MerchantApi
-import com.example.afterpay.data.MerchantCheckoutRequest
 import com.example.afterpay.util.asCurrency
 import com.example.afterpay.util.update
 import com.example.afterpay.util.viewModelFactory
@@ -68,7 +68,7 @@ class CheckoutViewModel(
 
             try {
                 val response = withContext(Dispatchers.IO) {
-                    merchantApi.checkout(MerchantCheckoutRequest(email, amount))
+                    merchantApi.checkout(CheckoutRequest(email, amount))
                 }
                 commandChannel.offer(Command.StartAfterpayCheckout(response.url))
             } catch (error: Exception) {

--- a/example/src/main/kotlin/com/example/afterpay/data/CheckoutRequest.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/CheckoutRequest.kt
@@ -1,0 +1,6 @@
+package com.example.afterpay.data
+
+data class CheckoutRequest(
+    val email: String,
+    val amount: String
+)

--- a/example/src/main/kotlin/com/example/afterpay/data/CheckoutResponse.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/CheckoutResponse.kt
@@ -1,0 +1,5 @@
+package com.example.afterpay.data
+
+data class CheckoutResponse(
+    val url: String
+)

--- a/example/src/main/kotlin/com/example/afterpay/data/ConfigurationResponse.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/ConfigurationResponse.kt
@@ -1,0 +1,11 @@
+package com.example.afterpay.data
+
+data class ConfigurationResponse(
+    val minimumAmount: Money?,
+    val maximumAmount: Money
+) {
+    data class Money(
+        val amount: String,
+        val currency: String
+    )
+}

--- a/example/src/main/kotlin/com/example/afterpay/data/MerchantApi.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/MerchantApi.kt
@@ -1,9 +1,13 @@
 package com.example.afterpay.data
 
 import retrofit2.http.Body
+import retrofit2.http.GET
 import retrofit2.http.POST
 
 interface MerchantApi {
+    @GET("configuration")
+    suspend fun configuration(): ConfigurationResponse
+
     @POST("checkouts")
     suspend fun checkout(@Body request: CheckoutRequest): CheckoutResponse
 }

--- a/example/src/main/kotlin/com/example/afterpay/data/MerchantApi.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/MerchantApi.kt
@@ -5,5 +5,5 @@ import retrofit2.http.POST
 
 interface MerchantApi {
     @POST("checkouts")
-    suspend fun checkout(@Body request: MerchantCheckoutRequest): MerchantCheckoutResponse
+    suspend fun checkout(@Body request: CheckoutRequest): CheckoutResponse
 }

--- a/example/src/main/kotlin/com/example/afterpay/data/MerchantCheckoutRequest.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/MerchantCheckoutRequest.kt
@@ -1,3 +1,0 @@
-package com.example.afterpay.data
-
-data class MerchantCheckoutRequest(val email: String, val amount: String)

--- a/example/src/main/kotlin/com/example/afterpay/data/MerchantCheckoutResponse.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/MerchantCheckoutResponse.kt
@@ -1,3 +1,0 @@
-package com.example.afterpay.data
-
-data class MerchantCheckoutResponse(val url: String)

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -10,4 +10,6 @@
     <string name="title_shopping">Aftersnack</string>
     <string name="title_checkout">Checkout</string>
     <string name="title_receipt">Receipt</string>
+    <string name="configuration_error_message">Failed to fetch Afterpay configuration</string>
+    <string name="configuration_error_action_retry">Retry</string>
 </resources>


### PR DESCRIPTION
## Summary of Changes

- Add `/configuration` server endpoint to example app.
- Apply configuration to SDK in the example app at checkout.
- Minor naming cleanup.

## Items of Note

The configuration request is executed when the checkout screen loads. This may not be the most optimal place for it but I imagine that's where most merchants integrating the SDK will do it.