### PR TITLE
Periodically refresh and cache Afterpay configuration in example app

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@ The Afterpay Android SDK makes it quick and easy to provide an excellent payment
     - [ProGuard](#proguard)
 - [Features](#features)
 - [Getting Started](#getting-started)
+    - [Configurating the SDK](#configuring-the-sdk)
+    - [Launching the Checkout](launching-the-checkout)
 - [Security](#security)
 - [Examples](#examples)
 - [Contributing](#contributing)
@@ -45,6 +47,26 @@ The initial release of the SDK contains the web login and checkout process with 
 
 ## Getting Started
 
+### Configuring the SDK
+
+Each merchant has configuration specific to their account which is accessible from the `/configuration` API endpoint. This configuration is used by the SDK for rendering UI components and is applied globally using the [`Afterpay.setConfiguration`][docs-configuration] method.
+
+The following sample demonstrates how the SDK can be configured using the data supplied by the Afterpay API.
+
+```kotlin
+val configuration = api.getConfiguration()
+
+Afterpay.setConfiguration(
+    minimumAmount = configuration.minimum?.amount,
+    maximumAmount = configuration.maximum.amount,
+    currency = configuration.maximum.currency
+)
+```
+
+> **NOTE:** The merchant account is subject to change and it is recommended to update this configuration **once per day**. The example project provides a [reference][example-configuration] demonstrating how this may be implemented.
+
+### Launching the Checkout
+
 Launch the Afterpay payment flow by starting the intent provided by the SDK for a given checkout URL.
 
 ```kotlin
@@ -58,7 +80,7 @@ class ExampleActivity: Activity {
 
         val afterpayCheckoutButton = findViewById<Button>(R.id.button_afterpay)
         afterpayCheckoutButton.setOnClickListener {
-            val checkoutUrl = merchantServer.checkoutWithAfterpay(cart)
+            val checkoutUrl = api.checkoutWithAfterpay(cart)
             val intent = Afterpay.createCheckoutIntent(this, checkoutUrl)
             startActivityForResult(intent, CHECKOUT_WITH_AFTERPAY)
         }
@@ -117,7 +139,9 @@ This project is licensed under the terms of the Apache 2.0 license. See the [LIC
 [badge-ci]: https://github.com/afterpay/sdk-android/workflows/Build%20and%20Test/badge.svg?branch=master&event=push
 [badge-ktlint]: https://img.shields.io/badge/code%20style-%E2%9D%A4-FF4081.svg
 [contributing]: CONTRIBUTING.md
+[docs-configuration]: https://github.com/afterpay/sdk-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L65
 [example]: example
+[example-configuration]: https://github.com/afterpay/sdk-android/blob/master/example/src/main/kotlin/com/example/afterpay/MainActivity.kt#L92-L100
 [ktlint]: https://ktlint.github.io
 [license]: LICENSE
 [network-config]: https://developer.android.com/training/articles/security-config#CertificatePinning

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ buildscript {
         'androidx_recycler_view': '1.1.0',
         'android_three_ten': '1.2.4',
         'app_compat': '1.1.0',
-        'core_ktx': '1.3.0',
+        'core_ktx': '1.3.1',
         'coroutines': '1.3.8',
         'material_design_components': '1.1.0',
         'moshi': '1.9.3',

--- a/build.gradle
+++ b/build.gradle
@@ -13,6 +13,7 @@ buildscript {
         'androidx_lifecycle': '2.2.0',
         'androidx_navigation': '2.3.0',
         'androidx_recycler_view': '1.1.0',
+        'android_three_ten': '1.2.4',
         'app_compat': '1.1.0',
         'core_ktx': '1.3.0',
         'coroutines': '1.3.8',

--- a/example/README.md
+++ b/example/README.md
@@ -10,19 +10,26 @@ The application requires the [sample integration server][sample-server] to check
 
 The example application is intentionally simple and makes use of standard Android conventions and components to ensure familiarity with the majority of Android developers. It also utilizes Kotlin features such as [coroutines][kotlin-coroutines] and [Flows][kotlin-flow] to simplify asynchronous server and UI interactions.
 
-The flow of the application can be broken down into the following screens:
+The flow of the application can be broken down into the following components:
 
+- [Main Activity](#main-activity)
 - [Product list](#product-list)
 - [Checkout](#checkout)
 - [Transaction Receipt](#transaction-receipt)
 
+### Main Activity
+
+The [main activity][activity-main] is responsible for fetching the merchant account configuration and applying it to the SDK.
+
+This operation is performed each time the Activity is created so the configuration received from the backend is cached in [`SharedPreferences`][shared-preferences]. To ensure that the configuration does not become outdated, an updated configuration is fetched when the cached value is more than a day old.
+
 ### Product list
 
-The product screen contains a list of grocery items which can be added to and removed from the cart. This screen has no contact with the Afterpay SDK and its role is merely to populate the cart with items to be purchased at checkout.
+The [product screen][fragment-products] contains a list of grocery items which can be added to and removed from the cart. This screen has no contact with the Afterpay SDK and its role is merely to populate the cart with items to be purchased at checkout.
 
 ### Checkout
 
-The checkout screen contains the logic for integration with the Afterpay SDK. It is also responsible for communicating with the server and acquiring the URL for initiating the Afterpay checkout flow.
+The [checkout screen][fragment-checkout] contains the logic for integration with the Afterpay SDK. It is also responsible for communicating with the server and acquiring the URL for initiating the Afterpay checkout flow.
 
 > **NOTE:** The app uses [the provided sample server][sample-server] for integration with the Afterpay API. A similar approach should be included with the backend your application uses to query for configuration and generate a checkout URL required to initiate the Afterpay SDK checkout flow.
 
@@ -36,14 +43,19 @@ If the transaction is cancelled at any point during the web checkout flow, the `
 
 ### Transaction Receipt
 
-The receipt screen displays the transaction token return by the SDK for a successful checkout flow. Navigating back from this screen will clear the cart and return to the product list to start a new shopping session.
+The [receipt screen][fragment-receipt] displays the transaction token return by the SDK for a successful checkout flow. Navigating back from this screen will clear the cart and return to the product list to start a new shopping session.
 
 <!-- Links: -->
+[activity-main]: https://github.com/afterpay/sdk-android/blob/master/example/src/main/kotlin/com/example/afterpay/MainActivity.kt
 [activity-start]: https://developer.android.com/reference/android/app/Activity#startActivityForResult(android.content.Intent,%20int)
 [activity-result]: https://developer.android.com/reference/android/app/Activity#onActivityResult(int,%20int,%20android.content.Intent)
+[fragment-checkout]: https://github.com/afterpay/sdk-android/blob/master/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+[fragment-products]: https://github.com/afterpay/sdk-android/blob/master/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+[fragment-receipt]: https://github.com/afterpay/sdk-android/blob/master/example/src/main/kotlin/com/example/afterpay/receipt/ReceiptFragment.kt
 [kotlin-coroutines]: https://developer.android.com/kotlin/coroutines
 [kotlin-flow]: https://kotlinlang.org/docs/reference/coroutines/flow.html
 [sample-server]: https://github.com/afterpay/sdk-example-server
 [sample-server-instructions]: https://github.com/afterpay/sdk-example-server#getting-started
 [sdk-create-checkout]: https://github.com/afterpay/sdk-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L19
 [sdk-parse-response]: https://github.com/afterpay/sdk-android/blob/master/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt#L30
+[shared-preferences]: https://developer.android.com/reference/android/content/SharedPreferences

--- a/example/build.gradle
+++ b/example/build.gradle
@@ -62,4 +62,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:${versions.okhttp}"
     implementation "com.squareup.retrofit2:retrofit:${versions.retrofit}"
     implementation "com.squareup.retrofit2:converter-moshi:${versions.retrofit}"
+    implementation "com.jakewharton.threetenabp:threetenabp:${versions.android_three_ten}"
 }

--- a/example/src/main/kotlin/com/example/afterpay/ExampleApplication.kt
+++ b/example/src/main/kotlin/com/example/afterpay/ExampleApplication.kt
@@ -2,6 +2,7 @@ package com.example.afterpay
 
 import android.app.Application
 import android.os.StrictMode
+import com.jakewharton.threetenabp.AndroidThreeTen
 
 @Suppress("unused")
 class ExampleApplication : Application() {
@@ -24,5 +25,7 @@ class ExampleApplication : Application() {
                     .build()
             )
         }
+
+        AndroidThreeTen.init(this)
     }
 }

--- a/example/src/main/kotlin/com/example/afterpay/MainActivity.kt
+++ b/example/src/main/kotlin/com/example/afterpay/MainActivity.kt
@@ -99,11 +99,12 @@ class MainActivity : AppCompatActivity() {
                 currencyCode = configuration.currency
             )
         } catch (e: Exception) {
-            Snackbar.make(
-                findViewById(android.R.id.content),
-                R.string.configuration_error_message,
-                Snackbar.LENGTH_INDEFINITE
-            )
+            Snackbar
+                .make(
+                    findViewById(android.R.id.content),
+                    R.string.configuration_error_message,
+                    Snackbar.LENGTH_INDEFINITE
+                )
                 .setAction(R.string.configuration_error_action_retry) {
                     lifecycleScope.launch {
                         applyAfterpayConfiguration()

--- a/example/src/main/kotlin/com/example/afterpay/MainActivity.kt
+++ b/example/src/main/kotlin/com/example/afterpay/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.example.afterpay
 
+import android.content.Context
 import android.content.pm.ActivityInfo
 import android.os.Bundle
 import androidx.appcompat.app.AppCompatActivity
@@ -13,14 +14,26 @@ import androidx.navigation.ui.AppBarConfiguration
 import androidx.navigation.ui.setupWithNavController
 import com.afterpay.android.Afterpay
 import com.example.afterpay.checkout.CheckoutFragment
+import com.example.afterpay.data.AfterpayRepository
 import com.example.afterpay.receipt.ReceiptFragment
 import com.example.afterpay.shopping.ShoppingFragment
 import com.google.android.material.snackbar.Snackbar
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 
 class MainActivity : AppCompatActivity() {
+    private val afterpayRepository by lazy {
+        AfterpayRepository(
+            merchantApi = Dependencies.merchantApi,
+            preferences = getSharedPreferences(
+                getString(R.string.preferences),
+                Context.MODE_PRIVATE
+            )
+        )
+    }
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
@@ -69,31 +82,34 @@ class MainActivity : AppCompatActivity() {
             }
         }
 
-        fetchAfterpayConfiguration()
+        lifecycleScope.launchWhenStarted {
+            applyAfterpayConfiguration()
+        }
     }
 
-    private fun fetchAfterpayConfiguration() {
-        lifecycleScope.launchWhenStarted {
-            try {
-                val configuration = withContext(Dispatchers.IO) {
-                    Dependencies.merchantApi.configuration()
-                }
-                Afterpay.setConfiguration(
-                    minimumAmount = configuration.minimumAmount?.amount,
-                    maximumAmount = configuration.maximumAmount.amount,
-                    currencyCode = configuration.maximumAmount.currency
-                )
-            } catch (_: Exception) {
-                Snackbar.make(
-                    findViewById(android.R.id.content),
-                    R.string.configuration_error_message,
-                    Snackbar.LENGTH_INDEFINITE
-                )
-                    .setAction(R.string.configuration_error_action_retry) {
-                        fetchAfterpayConfiguration()
-                    }
-                    .show()
+    private suspend fun applyAfterpayConfiguration() {
+        try {
+            val configuration = withContext(Dispatchers.IO) {
+                afterpayRepository.fetchConfiguration()
             }
+
+            Afterpay.setConfiguration(
+                minimumAmount = configuration.minimumAmount,
+                maximumAmount = configuration.maximumAmount,
+                currencyCode = configuration.currency
+            )
+        } catch (e: Exception) {
+            Snackbar.make(
+                findViewById(android.R.id.content),
+                R.string.configuration_error_message,
+                Snackbar.LENGTH_INDEFINITE
+            )
+                .setAction(R.string.configuration_error_action_retry) {
+                    lifecycleScope.launch {
+                        applyAfterpayConfiguration()
+                    }
+                }
+                .show()
         }
     }
 }

--- a/example/src/main/kotlin/com/example/afterpay/data/AfterpayRepository.kt
+++ b/example/src/main/kotlin/com/example/afterpay/data/AfterpayRepository.kt
@@ -1,0 +1,75 @@
+package com.example.afterpay.data
+
+import android.content.SharedPreferences
+import org.threeten.bp.Duration
+import org.threeten.bp.LocalDateTime
+import org.threeten.bp.format.DateTimeFormatter
+
+class AfterpayRepository(
+    private val merchantApi: MerchantApi,
+    private val preferences: SharedPreferences
+) {
+    data class Configuration(
+        val minimumAmount: String?,
+        val maximumAmount: String,
+        val currency: String
+    )
+
+    suspend fun fetchConfiguration(): Configuration {
+        val cachedConfiguration = preferences.getConfiguration()
+
+        return if (shouldRefreshConfiguration() || cachedConfiguration == null) {
+            merchantApi.configuration().let {
+                Configuration(
+                    minimumAmount = it.minimumAmount?.amount,
+                    maximumAmount = it.maximumAmount.amount,
+                    currency = it.maximumAmount.currency
+                )
+            }.also { configuration ->
+                with(preferences.edit()) {
+                    putConfiguration(configuration)
+                    putLastFetchDate(LocalDateTime.now())
+                    commit()
+                }
+            }
+        } else {
+            cachedConfiguration
+        }
+    }
+
+    private fun shouldRefreshConfiguration(): Boolean {
+        val lastFetchedDate = preferences.getLastFetchDate() ?: return true
+        val daysSinceLastFetch = Duration.between(lastFetchedDate, LocalDateTime.now()).toDays()
+        return daysSinceLastFetch > 1
+    }
+}
+
+private object PreferenceKey {
+    const val lastFetchDate = "lastFetchDate"
+    const val minimumAmount = "minimumAmount"
+    const val maximumAmount = "maximumAmount"
+    const val currency = "currency"
+}
+
+private fun SharedPreferences.getLastFetchDate(): LocalDateTime? =
+    getString(PreferenceKey.lastFetchDate, null)?.let {
+        LocalDateTime.parse(it, DateTimeFormatter.ISO_DATE_TIME)
+    }
+
+private fun SharedPreferences.getConfiguration(): AfterpayRepository.Configuration? {
+    return AfterpayRepository.Configuration(
+        minimumAmount = getString(PreferenceKey.minimumAmount, null),
+        maximumAmount = getString(PreferenceKey.maximumAmount, null) ?: return null,
+        currency = getString(PreferenceKey.currency, null) ?: return null
+    )
+}
+
+private fun SharedPreferences.Editor.putLastFetchDate(date: LocalDateTime) {
+    putString(PreferenceKey.lastFetchDate, date.format(DateTimeFormatter.ISO_DATE_TIME))
+}
+
+private fun SharedPreferences.Editor.putConfiguration(configuration: AfterpayRepository.Configuration) {
+    putString(PreferenceKey.minimumAmount, configuration.minimumAmount)
+    putString(PreferenceKey.maximumAmount, configuration.maximumAmount)
+    putString(PreferenceKey.currency, configuration.currency)
+}

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -12,4 +12,5 @@
     <string name="title_receipt">Receipt</string>
     <string name="configuration_error_message">Failed to fetch Afterpay configuration</string>
     <string name="configuration_error_action_retry">Retry</string>
+    <string name="preferences">com.example.afterpay.preferences</string>
 </resources>


### PR DESCRIPTION
## Summary of Changes

- Cache Afterpay configuration in shared preferences.
- Refresh configuration if cache is more than a day old.