### PR TITLE
Add Afterpay price breakdown component

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -82,7 +82,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
                 .append(" ")
                 .append(
                     resources.getString(R.string.price_breakdown_info_link),
-                    URLSpan("https://www.afterpay.com"),
+                    URLSpan("https://static-us.afterpay.com/javascript/modal/us_modal.html"),
                     Spannable.SPAN_INCLUSIVE_EXCLUSIVE
                 )
             contentDescription = resources.getString(R.string.price_breakdown_content_description)

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -1,0 +1,150 @@
+package com.afterpay.android.view
+
+import android.content.Context
+import android.graphics.Canvas
+import android.graphics.Paint
+import android.graphics.drawable.Drawable
+import android.text.Spannable
+import android.text.SpannableStringBuilder
+import android.text.method.LinkMovementMethod
+import android.text.style.ImageSpan
+import android.text.style.URLSpan
+import android.util.AttributeSet
+import android.util.TypedValue
+import android.view.Gravity
+import android.view.View
+import android.widget.FrameLayout
+import android.widget.TextView
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
+import com.afterpay.android.R
+
+class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
+    constructor(context: Context) : this(context, attrs = null)
+
+    var colorScheme: AfterpayColorScheme = AfterpayColorScheme.DEFAULT
+        set(value) {
+            field = value
+            updateText()
+            invalidate()
+            requestLayout()
+        }
+
+    private val textView: TextView = TextView(context).apply {
+        setTextColor(context.resolveColorAttr(android.R.attr.textColorPrimary))
+        setLineSpacing(0f, 1.2f)
+        textSize = 14f
+        movementMethod = LinkMovementMethod.getInstance()
+        gravity = Gravity.CENTER
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
+        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
+            gravity = Gravity.CENTER
+        }
+    }
+
+    init {
+        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
+        isFocusable = true
+
+        addView(textView)
+
+        context.theme
+            .obtainStyledAttributes(attrs, R.styleable.Afterpay, 0, 0)
+            .apply {
+                try {
+                    val value = getInteger(R.styleable.Afterpay_colorScheme, 0)
+                    colorScheme = AfterpayColorScheme.values()[value]
+                } finally {
+                    recycle()
+                }
+            }
+
+        updateText()
+    }
+
+    private fun updateText() {
+        val drawable = resources.getDrawable(colorScheme.badgeDrawable, null).apply {
+            val metrics = textView.paint.fontMetrics
+            val fontHeight = metrics.descent - metrics.ascent
+            val aspectRatio = intrinsicWidth / intrinsicHeight.toFloat()
+            val drawableHeight = fontHeight * 2.5
+            val drawableWidth = drawableHeight * aspectRatio
+            setBounds(0, 0, drawableWidth.toInt(), drawableHeight.toInt())
+        }
+
+        textView.apply {
+            text = SpannableStringBuilder()
+                .append(resources.getString(R.string.price_breakdown_total_cost))
+                .append(" ")
+                .append(" ", CenteredImageSpan(drawable), Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                .append(" ")
+                .append(
+                    resources.getString(R.string.price_breakdown_info_link),
+                    URLSpan("https://www.afterpay.com"),
+                    Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+                )
+            contentDescription = resources.getString(R.string.price_breakdown_content_description)
+        }
+    }
+}
+
+/**
+ * A vertically centered image span.
+ */
+private class CenteredImageSpan(drawable: Drawable) : ImageSpan(drawable) {
+    override fun getSize(
+        paint: Paint,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        fontMetricsInt: Paint.FontMetricsInt?
+    ): Int {
+        val drawable = drawable
+        val bounds = drawable.bounds
+        fontMetricsInt?.let {
+            val paintFontMetrics = paint.fontMetricsInt
+            val fontHeight = paintFontMetrics.descent - paintFontMetrics.ascent
+            val drawableHeight = drawable.bounds.height()
+
+            val centerY = paintFontMetrics.ascent + fontHeight / 2
+            it.ascent = centerY - drawableHeight / 2
+            it.top = it.ascent
+            it.bottom = centerY + drawableHeight / 2
+            it.descent = it.bottom
+        }
+        return bounds.right
+    }
+
+    override fun draw(
+        canvas: Canvas,
+        text: CharSequence,
+        start: Int,
+        end: Int,
+        x: Float,
+        top: Int,
+        y: Int,
+        bottom: Int,
+        paint: Paint
+    ) {
+        val drawable = drawable
+        canvas.save()
+        val fmPaint = paint.fontMetricsInt
+        val fontHeight = fmPaint.descent - fmPaint.ascent
+        val centerY = y + fmPaint.descent - fontHeight / 2
+        val translationY = centerY - drawable.bounds.height() / 2
+        canvas.translate(x, translationY.toFloat())
+        drawable.draw(canvas)
+        canvas.restore()
+    }
+}
+
+@ColorInt
+private fun Context.resolveColorAttr(@AttrRes colorAttr: Int): Int {
+    val attribute = TypedValue().also {
+        theme.resolveAttribute(colorAttr, it, true)
+    }
+    val colorRes = if (attribute.resourceId != 0) attribute.resourceId else attribute.data
+    return ContextCompat.getColor(this, colorRes)
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -33,6 +33,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
 
     private val textView: TextView = TextView(context).apply {
         setTextColor(context.resolveColorAttr(android.R.attr.textColorPrimary))
+        setLinkTextColor(context.resolveColorAttr(android.R.attr.textColorSecondary))
         setLineSpacing(0f, 1.2f)
         textSize = 14f
         movementMethod = LinkMovementMethod.getInstance()

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -8,4 +8,8 @@
 
     <string name="badge_content_description">After pay</string>
 
+    <string name="price_breakdown_total_cost">or 4 payments of $40.00 with</string>
+    <string name="price_breakdown_info_link">Info</string>
+    <string name="price_breakdown_content_description">Or four payments of $40.00 with Afterpay.</string>
+
 </resources>

--- a/example/src/main/res/layout/fragment_shopping.xml
+++ b/example/src/main/res/layout/fragment_shopping.xml
@@ -49,6 +49,15 @@
             app:layout_constraintTop_toTopOf="parent"
             tools:text="$10.00" />
 
+        <com.afterpay.android.view.AfterpayPriceBreakdown
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginVertical="12dp"
+            app:layout_constraintBottom_toTopOf="@id/shopping_button_viewCart"
+            app:layout_constraintEnd_toEndOf="parent"
+            app:layout_constraintStart_toStartOf="parent"
+            app:layout_constraintTop_toBottomOf="@id/shopping_totalCostLabel" />
+
         <com.google.android.material.button.MaterialButton
             android:id="@+id/shopping_button_viewCart"
             android:layout_width="wrap_content"


### PR DESCRIPTION
## Summary of Changes

- Add price breakdown component.

## Items of Note

Still using placeholder assets. Also the price is currently fixed and will be configurable in a future PR.

![Screenshot_1596413938](https://user-images.githubusercontent.com/5798516/89135814-7dfe6200-d573-11ea-9c61-6e7de2fe519c.png)
