### PR TITLE
Set amount for price breakdown

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -1,0 +1,23 @@
+package com.afterpay.android.internal
+
+import com.afterpay.android.Afterpay
+import java.math.BigDecimal
+import java.math.RoundingMode
+import java.text.NumberFormat
+
+internal sealed class AfterpayInstalment {
+    data class Available(val instalmentCost: String) : AfterpayInstalment()
+    object NoConfiguration : AfterpayInstalment()
+
+    companion object {
+        fun of(totalCost: BigDecimal): AfterpayInstalment {
+            val currency = Afterpay.configuration?.currency ?: return NoConfiguration
+
+            val currencyFormatter = NumberFormat.getCurrencyInstance().apply {
+                this.currency = currency
+            }
+            val instalment = (totalCost / 4.toBigDecimal()).setScale(2, RoundingMode.HALF_EVEN)
+            return Available(instalmentCost = currencyFormatter.format(instalment))
+        }
+    }
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -6,7 +6,9 @@ import java.math.RoundingMode
 import java.text.NumberFormat
 
 internal sealed class AfterpayInstalment {
-    data class Available(val instalmentCost: String) : AfterpayInstalment()
+    data class Available(
+        val instalmentAmount: String
+    ) : AfterpayInstalment()
 
     data class NotAvailable(
         val minimumAmount: String?,
@@ -32,7 +34,7 @@ internal sealed class AfterpayInstalment {
             }
 
             val instalment = (totalCost / 4.toBigDecimal()).setScale(2, RoundingMode.HALF_EVEN)
-            return Available(instalmentCost = currencyFormatter.format(instalment))
+            return Available(instalmentAmount = currencyFormatter.format(instalment))
         }
     }
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayBadge.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayBadge.kt
@@ -25,7 +25,7 @@ class AfterpayBadge(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         adjustViewBounds = true
         scaleType = ImageView.ScaleType.FIT_CENTER
         importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, 48.dp).apply {
+        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
             gravity = Gravity.CENTER
         }
     }
@@ -34,6 +34,7 @@ class AfterpayBadge(context: Context, attrs: AttributeSet?) : FrameLayout(contex
         contentDescription = resources.getString(R.string.badge_content_description)
         importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
         layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
+        minimumWidth = 64.dp
         isFocusable = true
 
         addView(badgeView)

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -115,46 +115,48 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
         }
     }
 
-    private fun generateContent(breakdown: AfterpayInstalment): Content = when (breakdown) {
-        is AfterpayInstalment.Available -> Content(
-            text = String.format(
-                resources.getString(R.string.price_breakdown_total_cost),
-                breakdown.instalmentAmount
-            ),
-            description = String.format(
-                resources.getString(R.string.price_breakdown_total_cost_description),
-                breakdown.instalmentAmount
+    private fun generateContent(afterpay: AfterpayInstalment): Content = when (afterpay) {
+        is AfterpayInstalment.Available ->
+            Content(
+                text = String.format(
+                    resources.getString(R.string.price_breakdown_total_cost),
+                    afterpay.instalmentAmount
+                ),
+                description = String.format(
+                    resources.getString(R.string.price_breakdown_total_cost_description),
+                    afterpay.instalmentAmount
+                )
             )
-        )
         is AfterpayInstalment.NotAvailable ->
-            if (breakdown.minimumAmount != null)
+            if (afterpay.minimumAmount != null)
                 Content(
                     text = String.format(
                         resources.getString(R.string.price_breakdown_limit),
-                        breakdown.minimumAmount,
-                        breakdown.maximumAmount
+                        afterpay.minimumAmount,
+                        afterpay.maximumAmount
                     ),
                     description = String.format(
                         resources.getString(R.string.price_breakdown_limit_description),
-                        breakdown.minimumAmount,
-                        breakdown.maximumAmount
+                        afterpay.minimumAmount,
+                        afterpay.maximumAmount
                     )
                 )
             else
                 Content(
                     text = String.format(
                         resources.getString(R.string.price_breakdown_upper_limit),
-                        breakdown.maximumAmount
+                        afterpay.maximumAmount
                     ),
                     description = String.format(
                         resources.getString(R.string.price_breakdown_upper_limit_description),
-                        breakdown.maximumAmount
+                        afterpay.maximumAmount
                     )
                 )
-        AfterpayInstalment.NoConfiguration -> Content(
-            text = resources.getString(R.string.price_breakdown_no_configuration),
-            description = resources.getString(R.string.price_breakdown_no_configuration_description)
-        )
+        AfterpayInstalment.NoConfiguration ->
+            Content(
+                text = resources.getString(R.string.price_breakdown_no_configuration),
+                description = resources.getString(R.string.price_breakdown_no_configuration_description)
+            )
     }
 }
 

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -30,7 +30,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
         val description: String
     )
 
-    var totalCost: BigDecimal = BigDecimal.ZERO
+    var totalAmount: BigDecimal = BigDecimal.ZERO
         set(value) {
             field = value
             updateText()
@@ -90,7 +90,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
             setBounds(0, 0, drawableWidth.toInt(), drawableHeight.toInt())
         }
 
-        val instalment = AfterpayInstalment.of(totalCost)
+        val instalment = AfterpayInstalment.of(totalAmount)
         val content = generateContent(instalment)
 
         textView.apply {
@@ -119,11 +119,11 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
         is AfterpayInstalment.Available -> Content(
             text = String.format(
                 resources.getString(R.string.price_breakdown_total_cost),
-                breakdown.instalmentCost
+                breakdown.instalmentAmount
             ),
             description = String.format(
                 resources.getString(R.string.price_breakdown_total_cost_description),
-                breakdown.instalmentCost
+                breakdown.instalmentAmount
             )
         )
         is AfterpayInstalment.NotAvailable ->

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -90,19 +90,27 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
             setBounds(0, 0, drawableWidth.toInt(), drawableHeight.toInt())
         }
 
-        val content = generateContent(AfterpayInstalment.of(totalCost))
+        val instalment = AfterpayInstalment.of(totalCost)
+        val content = generateContent(instalment)
 
         textView.apply {
-            text = SpannableStringBuilder()
-                .append(content.text)
-                .append(" ")
-                .append(" ", CenteredImageSpan(drawable), Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
-                .append(" ")
-                .append(
+            text = SpannableStringBuilder().apply {
+                if (instalment is AfterpayInstalment.NotAvailable) {
+                    append(" ", CenteredImageSpan(drawable), Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                    append(" ")
+                    append(content.text)
+                } else {
+                    append(content.text)
+                    append(" ")
+                    append(" ", CenteredImageSpan(drawable), Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                }
+                append(" ")
+                append(
                     resources.getString(R.string.price_breakdown_info_link),
                     URLSpan("https://static-us.afterpay.com/javascript/modal/us_modal.html"),
                     Spannable.SPAN_INCLUSIVE_EXCLUSIVE
                 )
+            }
             contentDescription = content.description
         }
     }
@@ -118,6 +126,31 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
                 breakdown.instalmentCost
             )
         )
+        is AfterpayInstalment.NotAvailable ->
+            if (breakdown.minimumAmount != null)
+                Content(
+                    text = String.format(
+                        resources.getString(R.string.price_breakdown_limit),
+                        breakdown.minimumAmount,
+                        breakdown.maximumAmount
+                    ),
+                    description = String.format(
+                        resources.getString(R.string.price_breakdown_limit_description),
+                        breakdown.minimumAmount,
+                        breakdown.maximumAmount
+                    )
+                )
+            else
+                Content(
+                    text = String.format(
+                        resources.getString(R.string.price_breakdown_upper_limit),
+                        breakdown.maximumAmount
+                    ),
+                    description = String.format(
+                        resources.getString(R.string.price_breakdown_upper_limit_description),
+                        breakdown.maximumAmount
+                    )
+                )
         AfterpayInstalment.NoConfiguration -> Content(
             text = resources.getString(R.string.price_breakdown_no_configuration),
             description = resources.getString(R.string.price_breakdown_no_configuration_description)

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -11,7 +11,6 @@ import android.text.style.ImageSpan
 import android.text.style.URLSpan
 import android.util.AttributeSet
 import android.util.TypedValue
-import android.view.Gravity
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
@@ -52,11 +51,8 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
         setLineSpacing(0f, 1.2f)
         textSize = 14f
         movementMethod = LinkMovementMethod.getInstance()
-        gravity = Gravity.CENTER
         importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
-        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT).apply {
-            gravity = Gravity.CENTER
-        }
+        layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
     }
 
     init {

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -10,6 +10,10 @@
 
     <string name="price_breakdown_total_cost">or 4 payments of %1$s with</string>
     <string name="price_breakdown_total_cost_description">Or four payments of %1$s with After pay.</string>
+    <string name="price_breakdown_limit">is available between %1$s–%2$s.</string>
+    <string name="price_breakdown_limit_description">After pay is available between %1$s–%2$s.</string>
+    <string name="price_breakdown_upper_limit">is available under %1$s.</string>
+    <string name="price_breakdown_upper_limit_description">After pay is available under %1$s.</string>
     <string name="price_breakdown_no_configuration">or pay with</string>
     <string name="price_breakdown_no_configuration_description">Or pay with After pay.</string>
     <string name="price_breakdown_info_link">Info</string>

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -8,9 +8,11 @@
 
     <string name="badge_content_description">After pay</string>
 
-    <string name="price_breakdown_total_cost">or 4 payments of $40.00 with</string>
+    <string name="price_breakdown_total_cost">or 4 payments of %1$s with</string>
+    <string name="price_breakdown_total_cost_description">Or four payments of %1$s with After pay.</string>
+    <string name="price_breakdown_no_configuration">or pay with</string>
+    <string name="price_breakdown_no_configuration_description">Or pay with After pay.</string>
     <string name="price_breakdown_info_link">Info</string>
-    <string name="price_breakdown_content_description">Or four payments of $40.00 with Afterpay.</string>
 
     <string name="payment_button_content_description">Pay now with After pay</string>
 

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
 import com.example.afterpay.nav_graph
@@ -60,12 +61,14 @@ class ShoppingFragment : Fragment() {
         }
 
         val totalCost = view.findViewById<TextView>(R.id.shopping_totalCost)
+        val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
 
         lifecycleScope.launchWhenCreated {
             viewModel.state.collectLatest { state ->
                 viewAdapter.submitList(state.shoppingItems)
                 checkoutButton.isEnabled = state.enableCheckoutButton
-                totalCost.text = state.totalCost
+                totalCost.text = state.totalCostFormatted
+                afterpayBreakdown.totalCost = state.totalCost
             }
         }
         lifecycleScope.launchWhenStarted {

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -68,7 +68,7 @@ class ShoppingFragment : Fragment() {
                 viewAdapter.submitList(state.shoppingItems)
                 checkoutButton.isEnabled = state.enableCheckoutButton
                 totalCost.text = state.totalCostFormatted
-                afterpayBreakdown.totalCost = state.totalCost
+                afterpayBreakdown.totalAmount = state.totalCost
             }
         }
         lifecycleScope.launchWhenStarted {

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingViewModel.kt
@@ -57,7 +57,10 @@ class ShoppingViewModel(val cart: Cart) : ViewModel() {
                 ShoppingItem(product, quantityInCart = summary.quantityOf(product))
             }
 
-        val totalCost: String
+        val totalCost: BigDecimal
+            get() = summary.totalCost
+
+        val totalCostFormatted: String
             get() = summary.totalCost.asCurrency()
 
         val enableCheckoutButton: Boolean

--- a/example/src/main/res/layout/fragment_shopping.xml
+++ b/example/src/main/res/layout/fragment_shopping.xml
@@ -49,6 +49,7 @@
             tools:text="$10.00" />
 
         <com.afterpay.android.view.AfterpayPriceBreakdown
+            android:id="@+id/shopping_afterpayPriceBreakdown"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginHorizontal="24dp"


### PR DESCRIPTION
## Summary of Changes

- Add total amount to price breakdown component to display Afterpay instalments.
- Handle cases where there is no configuration and where the total amount is outside the configuration limits.
- Set minimum width for Afterpay badge.

## Items of Note

I haven't heard back as to what text should be used when the configuration has not been set on the SDK but the "or pay with Afterpay" placeholder seems good enough for now.

![Price Breakdown](https://user-images.githubusercontent.com/5798516/89474306-97e4b280-d7c8-11ea-8fca-1a0625227242.png)

![No Configuration](https://user-images.githubusercontent.com/5798516/89474358-b480ea80-d7c8-11ea-8c20-dec10497fa1e.png)

![Not within Limit](https://user-images.githubusercontent.com/5798516/89479399-15fb8600-d7d6-11ea-8275-fd55aaeef412.png)

![Not under limit](https://user-images.githubusercontent.com/5798516/89479406-1a27a380-d7d6-11ea-82c0-3e5171f100c7.png)
