### PR TITLE
Display Afterpay info in modal WebView

### DIFF
--- a/afterpay/src/main/AndroidManifest.xml
+++ b/afterpay/src/main/AndroidManifest.xml
@@ -6,7 +6,7 @@
 
     <application>
         <activity
-            android:name=".view.WebCheckoutActivity"
+            android:name=".view.AfterpayCheckoutActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:theme="@style/AfterpayDialog" />
         <activity

--- a/afterpay/src/main/AndroidManifest.xml
+++ b/afterpay/src/main/AndroidManifest.xml
@@ -9,6 +9,10 @@
             android:name=".view.WebCheckoutActivity"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
             android:theme="@style/AfterpayDialog" />
+        <activity
+            android:name=".internal.AfterpayInfoActivity"
+            android:configChanges="orientation|screenSize|screenLayout|keyboardHidden"
+            android:theme="@style/AfterpayDialog" />
     </application>
 
 </manifest>

--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -3,9 +3,9 @@ package com.afterpay.android
 import android.content.Context
 import android.content.Intent
 import com.afterpay.android.internal.Configuration
-import com.afterpay.android.util.getCancellationStatusExtra
-import com.afterpay.android.util.getOrderTokenExtra
-import com.afterpay.android.util.putCheckoutUrlExtra
+import com.afterpay.android.internal.getCancellationStatusExtra
+import com.afterpay.android.internal.getOrderTokenExtra
+import com.afterpay.android.internal.putCheckoutUrlExtra
 import com.afterpay.android.view.WebCheckoutActivity
 import java.lang.IllegalArgumentException
 import java.lang.NumberFormatException

--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -6,7 +6,7 @@ import com.afterpay.android.internal.Configuration
 import com.afterpay.android.internal.getCancellationStatusExtra
 import com.afterpay.android.internal.getOrderTokenExtra
 import com.afterpay.android.internal.putCheckoutUrlExtra
-import com.afterpay.android.view.WebCheckoutActivity
+import com.afterpay.android.view.AfterpayCheckoutActivity
 import java.lang.IllegalArgumentException
 import java.lang.NumberFormatException
 import java.math.BigDecimal
@@ -26,7 +26,7 @@ object Afterpay {
      */
     @JvmStatic
     fun createCheckoutIntent(context: Context, checkoutUrl: String): Intent =
-        Intent(context, WebCheckoutActivity::class.java)
+        Intent(context, AfterpayCheckoutActivity::class.java)
             .putCheckoutUrlExtra(checkoutUrl)
 
     /**

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoActivity.kt
@@ -1,0 +1,33 @@
+package com.afterpay.android.internal
+
+import android.app.Activity
+import android.os.Bundle
+import android.view.ViewGroup
+import android.webkit.WebView
+import androidx.appcompat.app.AppCompatActivity
+import com.afterpay.android.R
+
+internal class AfterpayInfoActivity : AppCompatActivity() {
+    private lateinit var webView: WebView
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_web_checkout)
+
+        window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
+
+        webView = findViewById(R.id.afterpay_webView)
+
+        loadUrl()
+    }
+
+    private fun loadUrl() {
+        val url = intent.getInfoUrlExtra() ?: return dismiss()
+        webView.loadUrl(url)
+    }
+
+    private fun dismiss() {
+        setResult(Activity.RESULT_OK)
+        finish()
+    }
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoSpan.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoSpan.kt
@@ -1,0 +1,17 @@
+package com.afterpay.android.internal
+
+import android.content.Intent
+import android.text.style.URLSpan
+import android.view.View
+
+internal class AfterpayInfoSpan(url: String) : URLSpan(url) {
+    override fun onClick(widget: View) {
+        val context = widget.context
+        val intent = Intent(context, AfterpayInfoActivity::class.java).putInfoUrlExtra(url)
+        if (intent.resolveActivity(context.packageManager) != null) {
+            context.startActivity(intent)
+        } else {
+            super.onClick(widget)
+        }
+    }
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Context.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Context.kt
@@ -1,0 +1,16 @@
+package com.afterpay.android.internal
+
+import android.content.Context
+import android.util.TypedValue
+import androidx.annotation.AttrRes
+import androidx.annotation.ColorInt
+import androidx.core.content.ContextCompat
+
+@ColorInt
+internal fun Context.resolveColorAttr(@AttrRes colorAttr: Int): Int {
+    val attribute = TypedValue().also {
+        theme.resolveAttribute(colorAttr, it, true)
+    }
+    val colorRes = if (attribute.resourceId != 0) attribute.resourceId else attribute.data
+    return ContextCompat.getColor(this, colorRes)
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Intent.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Intent.kt
@@ -1,4 +1,4 @@
-package com.afterpay.android.util
+package com.afterpay.android.internal
 
 import android.content.Intent
 import com.afterpay.android.CancellationStatus
@@ -6,6 +6,7 @@ import java.lang.Exception
 
 private object AfterpayIntent {
     const val CHECKOUT_URL = "AFTERPAY_CHECKOUT_URL"
+    const val INFO_URL = "AFTERPAY_INFO_URL"
     const val ORDER_TOKEN = "AFTERPAY_ORDER_TOKEN"
     const val CANCELLATION_STATUS = "AFTERPAY_CANCELLATION_STATUS"
 }
@@ -30,3 +31,9 @@ internal fun Intent.getCancellationStatusExtra(): CancellationStatus? = try {
 } catch (_: Exception) {
     null
 }
+
+internal fun Intent.putInfoUrlExtra(url: String): Intent =
+    putExtra(AfterpayIntent.INFO_URL, url)
+
+internal fun Intent.getInfoUrlExtra(): String? =
+    getStringExtra(AfterpayIntent.INFO_URL)

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
@@ -19,7 +19,7 @@ import com.afterpay.android.internal.getCheckoutUrlExtra
 import com.afterpay.android.internal.putCancellationStatusExtra
 import com.afterpay.android.internal.putOrderTokenExtra
 
-internal class WebCheckoutActivity : AppCompatActivity() {
+internal class AfterpayCheckoutActivity : AppCompatActivity() {
     private companion object {
         val validCheckoutUrls = listOf("portal.afterpay.com", "portal.sandbox.afterpay.com")
         const val versionHeader = "${BuildConfig.VERSION_NAME}-android"

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -8,17 +8,14 @@ import android.text.Spannable
 import android.text.SpannableStringBuilder
 import android.text.method.LinkMovementMethod
 import android.text.style.ImageSpan
-import android.text.style.URLSpan
 import android.util.AttributeSet
-import android.util.TypedValue
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
-import androidx.annotation.AttrRes
-import androidx.annotation.ColorInt
-import androidx.core.content.ContextCompat
 import com.afterpay.android.R
+import com.afterpay.android.internal.AfterpayInfoSpan
 import com.afterpay.android.internal.AfterpayInstalment
+import com.afterpay.android.internal.resolveColorAttr
 import java.math.BigDecimal
 
 class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayout(context, attrs) {
@@ -103,7 +100,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
                 append(" ")
                 append(
                     resources.getString(R.string.price_breakdown_info_link),
-                    URLSpan("https://static-us.afterpay.com/javascript/modal/us_modal.html"),
+                    AfterpayInfoSpan("https://static-us.afterpay.com/javascript/modal/us_modal.html"),
                     Spannable.SPAN_INCLUSIVE_EXCLUSIVE
                 )
             }
@@ -204,13 +201,4 @@ private class CenteredImageSpan(drawable: Drawable) : ImageSpan(drawable) {
         drawable.draw(canvas)
         canvas.restore()
     }
-}
-
-@ColorInt
-private fun Context.resolveColorAttr(@AttrRes colorAttr: Int): Int {
-    val attribute = TypedValue().also {
-        theme.resolveAttribute(colorAttr, it, true)
-    }
-    val colorRes = if (attribute.resourceId != 0) attribute.resourceId else attribute.data
-    return ContextCompat.getColor(this, colorRes)
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/WebCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/WebCheckoutActivity.kt
@@ -15,9 +15,9 @@ import androidx.appcompat.app.AppCompatActivity
 import com.afterpay.android.BuildConfig
 import com.afterpay.android.CancellationStatus
 import com.afterpay.android.R
-import com.afterpay.android.util.getCheckoutUrlExtra
-import com.afterpay.android.util.putCancellationStatusExtra
-import com.afterpay.android.util.putOrderTokenExtra
+import com.afterpay.android.internal.getCheckoutUrlExtra
+import com.afterpay.android.internal.putCancellationStatusExtra
+import com.afterpay.android.internal.putOrderTokenExtra
 
 internal class WebCheckoutActivity : AppCompatActivity() {
     private companion object {


### PR DESCRIPTION
## Summary of Changes

- Display Afterpay info link in modal window.
- Move internal SDK extensions to `internal` package.
- Rename `WebCheckoutActivity` to `AfterpayCheckoutActivity` for consistency within the SDK.

## Items of Note

![Screenshot_1596695250](https://user-images.githubusercontent.com/5798516/89498627-ef534480-d801-11ea-9197-a6f606736103.png)
