### PR TITLE
Set the currencySymbol as per afterpay branding guidelines

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -22,18 +22,16 @@ internal sealed class AfterpayInstalment {
         fun of(totalCost: BigDecimal): AfterpayInstalment {
             val configuration = Afterpay.configuration ?: return NoConfiguration
 
-            val currencyFormatter = NumberFormat.getCurrencyInstance().apply {
+            val currencyFormatter = (NumberFormat.getCurrencyInstance() as DecimalFormat).apply {
                 currency = configuration.currency
-
-                val symbols = (this as DecimalFormat).decimalFormatSymbols
-                symbols.currencySymbol = when (configuration.currency.currencyCode) {
-                    "AUD" -> "A$"
-                    "NZD" -> "NZ$"
-                    "CAD" -> "CA$"
-                    else -> "$"
+                decimalFormatSymbols = decimalFormatSymbols.apply {
+                    currencySymbol = when (configuration.currency.currencyCode) {
+                        "AUD" -> "A$"
+                        "NZD" -> "NZ$"
+                        "CAD" -> "CA$"
+                        else -> "$"
+                    }
                 }
-
-                decimalFormatSymbols = symbols
             }
 
             val minimumAmount = configuration.minimumAmount ?: BigDecimal.ZERO

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -3,6 +3,7 @@ package com.afterpay.android.internal
 import com.afterpay.android.Afterpay
 import java.math.BigDecimal
 import java.math.RoundingMode
+import java.text.DecimalFormat
 import java.text.NumberFormat
 
 internal sealed class AfterpayInstalment {
@@ -23,6 +24,16 @@ internal sealed class AfterpayInstalment {
 
             val currencyFormatter = NumberFormat.getCurrencyInstance().apply {
                 currency = configuration.currency
+
+                val symbols = (this as DecimalFormat).decimalFormatSymbols
+                symbols.currencySymbol = when (configuration.currency.currencyCode) {
+                    "AUD" -> "A$"
+                    "NZD" -> "NZ$"
+                    "CAD" -> "CA$"
+                    else -> "$"
+                }
+
+                decimalFormatSymbols = symbols
             }
 
             val minimumAmount = configuration.minimumAmount ?: BigDecimal.ZERO


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Sets the currency symbol of the currency formatter in AfterpayInstalment

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

This cast seems safe with the reading I did.. A currency NumberFormat should always be a DecimalFormat