### PR TITLE
Update modal 'info' url to match the new region specific rebranded urls

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -12,6 +12,7 @@ import android.util.AttributeSet
 import android.view.View
 import android.widget.FrameLayout
 import android.widget.TextView
+import com.afterpay.android.Afterpay
 import com.afterpay.android.R
 import com.afterpay.android.internal.AfterpayInfoSpan
 import com.afterpay.android.internal.AfterpayInstalment
@@ -49,6 +50,16 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
         importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_NO
         layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
     }
+
+    // The terms and conditions are currently strongly tied to the configuration currency however
+    // this may change in the future to enable accounts paying in a foreign currency
+    private val infoUrl: String
+        get() = when (Afterpay.configuration?.currency?.currencyCode) {
+            "AUD" -> "https://static-us.afterpay.com/javascript/modal/au_rebrand_modal.html"
+            "NZD" -> "https://static-us.afterpay.com/javascript/modal/nz_rebrand_modal.html"
+            "CAD" -> "https://static-us.afterpay.com/javascript/modal/ca_rebrand_modal.html"
+            else -> "https://static-us.afterpay.com/javascript/modal/us_rebrand_modal.html"
+        }
 
     init {
         layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
@@ -114,7 +125,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
                 append(" ")
                 append(
                     resources.getString(R.string.price_breakdown_info_link),
-                    AfterpayInfoSpan("https://static-us.afterpay.com/javascript/modal/us_modal.html"),
+                    AfterpayInfoSpan(infoUrl),
                     Spannable.SPAN_INCLUSIVE_EXCLUSIVE
                 )
             }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Switches on the configuration currency code to load the correct info URL

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

This differs from the iOS implementation of storing and updating a locale. But it is also the simplest solution that can be updated if/when requirements call for it.