### PR TITLE
Don't attempt to format minimum value when null

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -37,7 +37,7 @@ internal sealed class AfterpayInstalment {
             val minimumAmount = configuration.minimumAmount ?: BigDecimal.ZERO
             if (totalCost < minimumAmount || totalCost > configuration.maximumAmount) {
                 return NotAvailable(
-                    minimumAmount = configuration.minimumAmount.let(currencyFormatter::format),
+                    minimumAmount = configuration.minimumAmount?.let(currencyFormatter::format),
                     maximumAmount = currencyFormatter.format(configuration.maximumAmount)
                 )
             }


### PR DESCRIPTION
## Summary of Changes

- Fix crash when attempting to format minimum value when null.

## Items of Note

Turns out `NumberFormat` doesn't like null values… who knew!?