### PR TITLE
Prefix resources to prevent undesired collisions

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -3,7 +3,16 @@
     <JetCodeStyleSettings>
       <option name="PACKAGES_TO_USE_STAR_IMPORTS">
         <value>
-          <package name="kotlinx.android.synthetic" withSubpackages="true" static="false" />
+          <package name="kotlinx.android.synthetic" alias="false" withSubpackages="true" />
+        </value>
+      </option>
+      <option name="PACKAGES_IMPORT_LAYOUT">
+        <value>
+          <package name="" alias="false" withSubpackages="true" />
+          <package name="java" alias="false" withSubpackages="true" />
+          <package name="javax" alias="false" withSubpackages="true" />
+          <package name="kotlin" alias="false" withSubpackages="true" />
+          <package name="" alias="true" withSubpackages="true" />
         </value>
       </option>
       <option name="NAME_COUNT_TO_USE_STAR_IMPORT" value="2147483647" />

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayBadge.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayBadge.kt
@@ -31,7 +31,7 @@ class AfterpayBadge(context: Context, attrs: AttributeSet?) : FrameLayout(contex
     }
 
     init {
-        contentDescription = resources.getString(R.string.badge_content_description)
+        contentDescription = resources.getString(R.string.afterpay_badge_content_description)
         importantForAccessibility = View.IMPORTANT_FOR_ACCESSIBILITY_YES
         layoutParams = LayoutParams(LayoutParams.WRAP_CONTENT, LayoutParams.WRAP_CONTENT)
         minimumWidth = 64.dp

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayBadge.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayBadge.kt
@@ -41,7 +41,7 @@ class AfterpayBadge(context: Context, attrs: AttributeSet?) : FrameLayout(contex
 
         context.theme.obtainStyledAttributes(attrs, R.styleable.Afterpay, 0, 0).apply {
             try {
-                val value = getInteger(R.styleable.Afterpay_colorScheme, 0)
+                val value = getInteger(R.styleable.Afterpay_afterpayColorScheme, 0)
                 colorScheme = AfterpayColorScheme.values()[value]
             } finally {
                 recycle()

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
@@ -84,13 +84,13 @@ internal class AfterpayCheckoutActivity : AppCompatActivity() {
         webView.loadUrl("about:blank")
 
         AlertDialog.Builder(this)
-            .setTitle(R.string.load_error_title)
-            .setMessage(R.string.load_error_message)
-            .setPositiveButton(R.string.load_error_retry) { dialog, _ ->
+            .setTitle(R.string.afterpay_load_error_title)
+            .setMessage(R.string.afterpay_load_error_message)
+            .setPositiveButton(R.string.afterpay_load_error_retry) { dialog, _ ->
                 loadCheckoutUrl()
                 dialog.dismiss()
             }
-            .setNegativeButton(R.string.load_error_cancel) { dialog, _ ->
+            .setNegativeButton(R.string.afterpay_load_error_cancel) { dialog, _ ->
                 dialog.cancel()
             }
             .setOnCancelListener {

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPaymentButton.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPaymentButton.kt
@@ -26,7 +26,7 @@ class AfterpayPaymentButton(
 
         context.theme.obtainStyledAttributes(attrs, R.styleable.Afterpay, 0, 0).apply {
             try {
-                val value = getInteger(R.styleable.Afterpay_colorScheme, 0)
+                val value = getInteger(R.styleable.Afterpay_afterpayColorScheme, 0)
                 colorScheme = AfterpayColorScheme.values()[value]
             } finally {
                 recycle()

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPaymentButton.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPaymentButton.kt
@@ -20,7 +20,7 @@ class AfterpayPaymentButton(
         }
 
     init {
-        contentDescription = resources.getString(R.string.payment_button_content_description)
+        contentDescription = resources.getString(R.string.afterpay_payment_button_content_description)
         adjustViewBounds = true
         background = null
 

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -124,7 +124,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
                 }
                 append(" ")
                 append(
-                    resources.getString(R.string.price_breakdown_info_link),
+                    resources.getString(R.string.afterpay_price_breakdown_info_link),
                     AfterpayInfoSpan(infoUrl),
                     Spannable.SPAN_INCLUSIVE_EXCLUSIVE
                 )
@@ -137,11 +137,11 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
         is AfterpayInstalment.Available ->
             Content(
                 text = String.format(
-                    resources.getString(R.string.price_breakdown_total_cost),
+                    resources.getString(R.string.afterpay_price_breakdown_total_cost),
                     afterpay.instalmentAmount
                 ),
                 description = String.format(
-                    resources.getString(R.string.price_breakdown_total_cost_description),
+                    resources.getString(R.string.afterpay_price_breakdown_total_cost_description),
                     afterpay.instalmentAmount
                 )
             )
@@ -149,12 +149,12 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
             if (afterpay.minimumAmount != null)
                 Content(
                     text = String.format(
-                        resources.getString(R.string.price_breakdown_limit),
+                        resources.getString(R.string.afterpay_price_breakdown_limit),
                         afterpay.minimumAmount,
                         afterpay.maximumAmount
                     ),
                     description = String.format(
-                        resources.getString(R.string.price_breakdown_limit_description),
+                        resources.getString(R.string.afterpay_price_breakdown_limit_description),
                         afterpay.minimumAmount,
                         afterpay.maximumAmount
                     )
@@ -162,18 +162,18 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
             else
                 Content(
                     text = String.format(
-                        resources.getString(R.string.price_breakdown_upper_limit),
+                        resources.getString(R.string.afterpay_price_breakdown_upper_limit),
                         afterpay.maximumAmount
                     ),
                     description = String.format(
-                        resources.getString(R.string.price_breakdown_upper_limit_description),
+                        resources.getString(R.string.afterpay_price_breakdown_upper_limit_description),
                         afterpay.maximumAmount
                     )
                 )
         AfterpayInstalment.NoConfiguration ->
             Content(
-                text = resources.getString(R.string.price_breakdown_no_configuration),
-                description = resources.getString(R.string.price_breakdown_no_configuration_description)
+                text = resources.getString(R.string.afterpay_price_breakdown_no_configuration),
+                description = resources.getString(R.string.afterpay_price_breakdown_no_configuration_description)
             )
     }
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -72,7 +72,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
             .obtainStyledAttributes(attrs, R.styleable.Afterpay, 0, 0)
             .apply {
                 try {
-                    val value = getInteger(R.styleable.Afterpay_colorScheme, 0)
+                    val value = getInteger(R.styleable.Afterpay_afterpayColorScheme, 0)
                     colorScheme = AfterpayColorScheme.values()[value]
                 } finally {
                     recycle()

--- a/afterpay/src/main/res/values/attrs.xml
+++ b/afterpay/src/main/res/values/attrs.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
     <declare-styleable name="Afterpay">
-        <attr name="colorScheme" format="enum">
+        <attr name="afterpayColorScheme" format="enum">
             <enum name="blackOnMint" value="0" />
             <enum name="mintOnBlack" value="1" />
             <enum name="whiteOnBlack" value="2" />

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -1,23 +1,23 @@
 <?xml version="1.0" encoding="utf-8"?>
 <resources>
 
-    <string name="load_error_title">Error</string>
-    <string name="load_error_message">Failed to load Afterpay checkout</string>
-    <string name="load_error_retry">Retry</string>
-    <string name="load_error_cancel">Cancel</string>
+    <string name="afterpay_load_error_title">Error</string>
+    <string name="afterpay_load_error_message">Failed to load Afterpay checkout</string>
+    <string name="afterpay_load_error_retry">Retry</string>
+    <string name="afterpay_load_error_cancel">Cancel</string>
 
-    <string name="badge_content_description">After pay</string>
+    <string name="afterpay_badge_content_description">After pay</string>
 
-    <string name="price_breakdown_total_cost">or 4 interest-free payments of %1$s with</string>
-    <string name="price_breakdown_total_cost_description">Or four interest free payments of %1$s with After pay</string>
-    <string name="price_breakdown_limit">available for orders between %1$s – %2$s</string>
-    <string name="price_breakdown_limit_description">After pay available for orders between %1$s – %2$s</string>
-    <string name="price_breakdown_upper_limit">available for orders up to %1$s</string>
-    <string name="price_breakdown_upper_limit_description">After pay available for orders up to %1$s</string>
-    <string name="price_breakdown_no_configuration">or pay with</string>
-    <string name="price_breakdown_no_configuration_description">Or pay with After pay</string>
-    <string name="price_breakdown_info_link">Info</string>
+    <string name="afterpay_price_breakdown_total_cost">or 4 interest-free payments of %1$s with</string>
+    <string name="afterpay_price_breakdown_total_cost_description">Or four interest free payments of %1$s with After pay</string>
+    <string name="afterpay_price_breakdown_limit">available for orders between %1$s – %2$s</string>
+    <string name="afterpay_price_breakdown_limit_description">After pay available for orders between %1$s – %2$s</string>
+    <string name="afterpay_price_breakdown_upper_limit">available for orders up to %1$s</string>
+    <string name="afterpay_price_breakdown_upper_limit_description">After pay available for orders up to %1$s</string>
+    <string name="afterpay_price_breakdown_no_configuration">or pay with</string>
+    <string name="afterpay_price_breakdown_no_configuration_description">Or pay with After pay</string>
+    <string name="afterpay_price_breakdown_info_link">Info</string>
 
-    <string name="payment_button_content_description">Pay now with After pay</string>
+    <string name="afterpay_payment_button_content_description">Pay now with After pay</string>
 
 </resources>


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Prefixes string resources
- Prefixes color schemes

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

All Android resources are flattened when Android apps are built which can cause collision errors:
https://stackoverflow.com/questions/16350957/why-android-cannot-deal-with-resources-name-conflict-between-project-and-library