### PR TITLE
Update Gradle and Android Gradle Plugin

### DIFF
--- a/afterpay/build.gradle
+++ b/afterpay/build.gradle
@@ -9,7 +9,7 @@ android {
     defaultConfig {
         minSdkVersion versions.min_sdk
         targetSdkVersion versions.compile_sdk
-        versionName VERSION_NAME
+        buildConfigField 'String', 'AfterpayLibraryVersion', "\"$VERSION_NAME\""
 
         consumerProguardFiles 'consumer-rules.pro'
     }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
@@ -22,7 +22,7 @@ import com.afterpay.android.internal.putOrderTokenExtra
 internal class AfterpayCheckoutActivity : AppCompatActivity() {
     private companion object {
         val validCheckoutUrls = listOf("portal.afterpay.com", "portal.sandbox.afterpay.com")
-        const val versionHeader = "${BuildConfig.VERSION_NAME}-android"
+        const val versionHeader = "${BuildConfig.AfterpayLibraryVersion}-android"
     }
 
     private lateinit var webView: WebView

--- a/build.gradle
+++ b/build.gradle
@@ -4,7 +4,7 @@ buildscript {
         'min_sdk': 21,
         'java': '1.8',
         'build_tools': '29.0.3',
-        'android_gradle_plugin': '4.0.1',
+        'android_gradle_plugin': '4.1.0',
         'kotlin': '1.3.72',
         'maven_publish_plugin': '0.12.0',
         'androidx_activity': '1.1.0',

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Jun 03 15:38:55 AEST 2020
+#Mon Oct 19 15:09:25 AEDT 2020
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.1.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5-all.zip


### PR DESCRIPTION
## Summary of Changes

- Update Gradle to v6.5
- Update Android Gradle plugin to v4.1.0
- Fix version name issues introduced with latest Android Gradle plugin.

## Items of Note

The latest version of the Android Gradle plugin has removed `BuildConfig.VERSION_NAME` for library modules. This was done to avoid confusion with the version name generated for the application, as justified [in the release notes](https://developer.android.com/studio/releases/gradle-plugin#version_properties_removed_from_buildconfig_class_in_library_projects).

To work around this the custom build config variable `AfterpayLibraryVersion` is used to define the current library version for use in the version header included in the web checkout flow.