### PR TITLE
Update currency formatting to respect locale and follow Afterpay business rules

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -27,14 +27,6 @@ object Afterpay {
     internal val locale: Locale
         get() = configuration?.locale ?: Locales.US
 
-    private val validLocaleCountries = setOf(
-        Locales.AUSTRALIA.country,
-        Locales.CANADA.country,
-        Locales.UK.country,
-        Locales.NEW_ZEALAND.country,
-        Locales.US.country
-    )
-
     /**
      * Creates an [Intent] that can be used to initiate an Afterpay transaction. Provide the
      * new [Intent] in [startActivityForResult][android.app.Activity.startActivityForResult]
@@ -104,10 +96,13 @@ object Afterpay {
                     throw IllegalArgumentException("Minimum order amount is invalid")
                 }
             }
-            if (!validLocaleCountries.contains(configuration.locale.country)) {
+
+            val validCountries = Locales.validSet.map { it.country }
+
+            if (!validCountries.contains(configuration.locale.country)) {
                 throw IllegalArgumentException(
                     "Locale contains an unsupported country: ${configuration.locale.country}. " +
-                        "Supported countries include: ${validLocaleCountries.joinToString(",")}"
+                        "Supported countries include: ${validCountries.joinToString(",")}"
                 )
             }
         }

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -4,6 +4,7 @@ import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
 import java.text.NumberFormat
+import java.util.Currency
 
 internal sealed class AfterpayInstalment {
     data class Available(
@@ -23,17 +24,43 @@ internal sealed class AfterpayInstalment {
                 return NoConfiguration
             }
 
-            val currencyFormatter = (NumberFormat.getCurrencyInstance() as DecimalFormat).apply {
-                currency = configuration.currency
-                decimalFormatSymbols = decimalFormatSymbols.apply {
-                    currencySymbol = when (configuration.currency.currencyCode) {
-                        "AUD" -> "A$"
-                        "NZD" -> "NZ$"
-                        "CAD" -> "CA$"
-                        else -> "$"
+            val locale = configuration.locale
+            val currency = configuration.currency
+            val currencyFormatter: NumberFormat
+            val isLocalCurrency = currency == Currency.getInstance(locale)
+
+            if (locale == Locales.US || isLocalCurrency) {
+                currencyFormatter = NumberFormat.getCurrencyInstance(locale)
+
+                (currencyFormatter as DecimalFormat).apply {
+                    this.currency = currency
+
+                    if (locale == Locales.US) {
+                        decimalFormatSymbols = decimalFormatSymbols.apply {
+                            currencySymbol = when (currency.currencyCode) {
+                                "AUD" -> "A$"
+                                "NZD" -> "NZ$"
+                                "CAD" -> "CA$"
+                                "GBP" -> "£"
+                                else -> currency.getSymbol(locale)
+                            }
+                        }
+                    }
+                }
+            } else {
+                val currencyLocale = Locales.validSet.first { Currency.getInstance(it) == currency }
+                currencyFormatter = NumberFormat.getCurrencyInstance(currencyLocale)
+
+                (currencyFormatter as DecimalFormat).apply {
+                    this.currency = currency
+
+                    if (!isLocalCurrency && currency.getSymbol(currencyLocale) == Currency.getInstance(Locales.US).getSymbol(Locales.US)) {
+                        this.applyPattern("¤#,##0.00 ¤¤")
                     }
                 }
             }
+
+
 
             val minimumAmount = configuration.minimumAmount ?: BigDecimal.ZERO
             if (totalCost < minimumAmount || totalCost > configuration.maximumAmount) {

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -1,6 +1,5 @@
 package com.afterpay.android.internal
 
-import com.afterpay.android.Afterpay
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
@@ -19,8 +18,10 @@ internal sealed class AfterpayInstalment {
     object NoConfiguration : AfterpayInstalment()
 
     companion object {
-        fun of(totalCost: BigDecimal): AfterpayInstalment {
-            val configuration = Afterpay.configuration ?: return NoConfiguration
+        fun of(totalCost: BigDecimal, configuration: Configuration?): AfterpayInstalment {
+            if (configuration == null) {
+                return NoConfiguration
+            }
 
             val currencyFormatter = (NumberFormat.getCurrencyInstance() as DecimalFormat).apply {
                 currency = configuration.currency

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Locales.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Locales.kt
@@ -5,8 +5,8 @@ import java.util.Locale
 object Locales {
 
     val AUSTRALIA = Locale("en", "AU")
-    val CANADA = Locale.CANADA
+    val CANADA: Locale = Locale.CANADA
     val NEW_ZEALAND = Locale("en", "NZ")
-    val UK = Locale.UK
-    val US = Locale.US
+    val UK: Locale = Locale.UK
+    val US: Locale = Locale.US
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Locales.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Locales.kt
@@ -2,11 +2,13 @@ package com.afterpay.android.internal
 
 import java.util.Locale
 
-object Locales {
+internal object Locales {
 
     val AUSTRALIA = Locale("en", "AU")
     val CANADA: Locale = Locale.CANADA
     val NEW_ZEALAND = Locale("en", "NZ")
     val UK: Locale = Locale.UK
     val US: Locale = Locale.US
+
+    val validSet = setOf(AUSTRALIA, CANADA, UK, NEW_ZEALAND, US)
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -106,7 +106,7 @@ class AfterpayPriceBreakdown(context: Context, attrs: AttributeSet?) : FrameLayo
             setBounds(0, 0, drawableWidth.toInt(), drawableHeight.toInt())
         }
 
-        val instalment = AfterpayInstalment.of(totalAmount)
+        val instalment = AfterpayInstalment.of(totalAmount, Afterpay.configuration)
         val content = generateContent(instalment)
 
         textView.apply {

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentTest.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentTest.kt
@@ -10,7 +10,6 @@ import java.util.Currency
 import java.util.Locale
 
 class AfterpayInstalmentTest {
-
     private val australianDollar: Currency = Currency.getInstance("AUD")
     private val canadianDollar: Currency = Currency.getInstance("CAD")
     private val poundSterling: Currency = Currency.getInstance("GBP")
@@ -112,5 +111,4 @@ class AfterpayInstalmentTest {
         val configuration = Configuration(50.toBigDecimal(), 1000.toBigDecimal(), currency, locale)
         return AfterpayInstalment.of(amount, configuration) as AfterpayInstalment.Available
     }
-
 }

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentTest.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentTest.kt
@@ -1,0 +1,116 @@
+package com.afterpay.android
+
+import com.afterpay.android.internal.AfterpayInstalment
+import com.afterpay.android.internal.Configuration
+import com.afterpay.android.internal.Locales
+import org.junit.Assert.assertEquals
+import org.junit.Test
+import java.math.BigDecimal
+import java.util.Currency
+import java.util.Locale
+
+class AfterpayInstalmentTest {
+
+    private val australianDollar: Currency = Currency.getInstance("AUD")
+    private val canadianDollar: Currency = Currency.getInstance("CAD")
+    private val poundSterling: Currency = Currency.getInstance("GBP")
+    private val newZealandDollar: Currency = Currency.getInstance("NZD")
+    private val unitedStatesDollar: Currency = Currency.getInstance("USD")
+
+    private val oneHundredAndTwenty = 120.toBigDecimal()
+
+    @Test
+    fun `available instalment in Australia locale`() {
+        val locale = Locales.AUSTRALIA
+
+        val audInstalment = availableInstalment(oneHundredAndTwenty, australianDollar, locale)
+        val cadInstalment = availableInstalment(oneHundredAndTwenty, canadianDollar, locale)
+        val gbpInstalment = availableInstalment(oneHundredAndTwenty, poundSterling, locale)
+        val nzdInstalment = availableInstalment(oneHundredAndTwenty, newZealandDollar, locale)
+        val usdInstalment = availableInstalment(oneHundredAndTwenty, unitedStatesDollar, locale)
+
+        assertEquals("$30.00", audInstalment.instalmentAmount)
+        assertEquals("$30.00 CAD", cadInstalment.instalmentAmount)
+        assertEquals("£30.00", gbpInstalment.instalmentAmount)
+        assertEquals("$30.00 NZD", nzdInstalment.instalmentAmount)
+        assertEquals("$30.00 USD", usdInstalment.instalmentAmount)
+    }
+
+    @Test
+    fun `available instalment in Canada locale`() {
+        val locale = Locales.CANADA
+
+        val audInstalment = availableInstalment(oneHundredAndTwenty, australianDollar, locale)
+        val cadInstalment = availableInstalment(oneHundredAndTwenty, canadianDollar, locale)
+        val gbpInstalment = availableInstalment(oneHundredAndTwenty, poundSterling, locale)
+        val nzdInstalment = availableInstalment(oneHundredAndTwenty, newZealandDollar, locale)
+        val usdInstalment = availableInstalment(oneHundredAndTwenty, unitedStatesDollar, locale)
+
+        assertEquals("$30.00 AUD", audInstalment.instalmentAmount)
+        assertEquals("$30.00", cadInstalment.instalmentAmount)
+        assertEquals("£30.00", gbpInstalment.instalmentAmount)
+        assertEquals("$30.00 NZD", nzdInstalment.instalmentAmount)
+        assertEquals("$30.00 USD", usdInstalment.instalmentAmount)
+    }
+
+    @Test
+    fun `available instalment in UK locale`() {
+        val locale = Locales.UK
+
+        val audInstalment = availableInstalment(oneHundredAndTwenty, australianDollar, locale)
+        val cadInstalment = availableInstalment(oneHundredAndTwenty, canadianDollar, locale)
+        val gbpInstalment = availableInstalment(oneHundredAndTwenty, poundSterling, locale)
+        val nzdInstalment = availableInstalment(oneHundredAndTwenty, newZealandDollar, locale)
+        val usdInstalment = availableInstalment(oneHundredAndTwenty, unitedStatesDollar, locale)
+
+        assertEquals("$30.00 AUD", audInstalment.instalmentAmount)
+        assertEquals("$30.00 CAD", cadInstalment.instalmentAmount)
+        assertEquals("£30.00", gbpInstalment.instalmentAmount)
+        assertEquals("$30.00 NZD", nzdInstalment.instalmentAmount)
+        assertEquals("$30.00 USD", usdInstalment.instalmentAmount)
+    }
+
+    @Test
+    fun `available instalment in New Zealand locale`() {
+        val locale = Locales.NEW_ZEALAND
+
+        val audInstalment = availableInstalment(oneHundredAndTwenty, australianDollar, locale)
+        val cadInstalment = availableInstalment(oneHundredAndTwenty, canadianDollar, locale)
+        val gbpInstalment = availableInstalment(oneHundredAndTwenty, poundSterling, locale)
+        val nzdInstalment = availableInstalment(oneHundredAndTwenty, newZealandDollar, locale)
+        val usdInstalment = availableInstalment(oneHundredAndTwenty, unitedStatesDollar, locale)
+
+        assertEquals("$30.00 AUD", audInstalment.instalmentAmount)
+        assertEquals("$30.00 CAD", cadInstalment.instalmentAmount)
+        assertEquals("£30.00", gbpInstalment.instalmentAmount)
+        assertEquals("$30.00", nzdInstalment.instalmentAmount)
+        assertEquals("$30.00 USD", usdInstalment.instalmentAmount)
+    }
+
+    @Test
+    fun `available instalment in US locale`() {
+        val locale = Locales.US
+
+        val audInstalment = availableInstalment(oneHundredAndTwenty, australianDollar, locale)
+        val cadInstalment = availableInstalment(oneHundredAndTwenty, canadianDollar, locale)
+        val gbpInstalment = availableInstalment(oneHundredAndTwenty, poundSterling, locale)
+        val nzdInstalment = availableInstalment(oneHundredAndTwenty, newZealandDollar, locale)
+        val usdInstalment = availableInstalment(oneHundredAndTwenty, unitedStatesDollar, locale)
+
+        assertEquals("A$30.00", audInstalment.instalmentAmount)
+        assertEquals("CA$30.00", cadInstalment.instalmentAmount)
+        assertEquals("£30.00", gbpInstalment.instalmentAmount)
+        assertEquals("NZ$30.00", nzdInstalment.instalmentAmount)
+        assertEquals("$30.00", usdInstalment.instalmentAmount)
+    }
+
+    private fun availableInstalment(
+        amount: BigDecimal,
+        currency: Currency,
+        locale: Locale
+    ): AfterpayInstalment.Available {
+        val configuration = Configuration(50.toBigDecimal(), 1000.toBigDecimal(), currency, locale)
+        return AfterpayInstalment.of(amount, configuration) as AfterpayInstalment.Available
+    }
+
+}


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Configuration is now injected into `AfterpayInstalment`
- Currency now takes into account the currency local to the configured locale and the international currency code is appended if it is a foreign dollar currency
- Special US currency symbols are retained

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

Currency rules are derived from the js sandbox: https://js.sandbox.afterpay.com/index.html

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] Tests are included.
- [x] Documentation is changed or added.
