### PR TITLE
Open external links via onCreateWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Add `afterpay-android` to your `build.gradle` dependencies.
 
 ```gradle
 dependencies {
-    implementation 'com.afterpay:afterpay-android:1.2.0'
+    implementation 'com.afterpay:afterpay-android:1.2.1'
 }
 ```
 

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
@@ -160,6 +160,10 @@ private class AfterpayWebViewClient(
 private class AfterpayWebChromeClient(
     private val openExternalLink: (Uri) -> Unit
 ) : WebChromeClient() {
+    companion object {
+        const val URL_KEY = "url"
+    }
+
     override fun onCreateWindow(
         view: WebView?,
         isDialog: Boolean,
@@ -169,9 +173,8 @@ private class AfterpayWebChromeClient(
         val hrefMessage = view?.handler?.obtainMessage()
         view?.requestFocusNodeHref(hrefMessage)
 
-        hrefMessage?.data?.getString("url")?.let {
-            openExternalLink(Uri.parse(it))
-        }
+        val url = hrefMessage?.data?.getString(URL_KEY)
+        url?.let { openExternalLink(Uri.parse(it)) }
 
         return false
     }

--- a/example/src/main/res/xml/network_security_config.xml
+++ b/example/src/main/res/xml/network_security_config.xml
@@ -26,6 +26,7 @@
             expiration="2021-07-05"
             tools:ignore="MissingBackupPin">
             <pin digest="SHA-256">15mVY9KpcF6J/UzKCS2AfUjUWPVsIvxi9PW0XuFnvH4=</pin>
+            <pin digest="SHA-256">FEzVOUp4dF3gI0ZVPRJhFbSJVXR+uQmMH65xhs1glH4=</pin>
         </pin-set>
     </domain-config>
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
 GROUP=com.afterpay
-VERSION_NAME=1.2.0-SNAPSHOT
+VERSION_NAME=1.2.1-SNAPSHOT
 
 POM_URL=https://github.com/afterpay/sdk-android/
 POM_SCM_URL=https://github.com/afterpay/sdk-android/


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Remove `linksToOpenExternally`
- Use `setSupportMultipleWindows` to enable the `onCreateWindow` hook
- Implement `AfterpayWebChromeClient`
- Open external URLs by accessing the last tapped href (a tag)
- Add SSL PIN to the sandbox enviroment in the example project

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

To be released in version `1.2.1`