### PR TITLE
Set custom user agent

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoActivity.kt
@@ -16,7 +16,8 @@ internal class AfterpayInfoActivity : AppCompatActivity() {
 
         window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 
-        webView = findViewById(R.id.afterpay_webView)
+        webView = findViewById<WebView>(R.id.afterpay_webView)
+            .setAfterpayUserAgentString()
 
         loadUrl()
     }

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/WebView.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/WebView.kt
@@ -1,0 +1,8 @@
+package com.afterpay.android.internal
+
+import android.webkit.WebView
+import com.afterpay.android.BuildConfig
+
+internal fun WebView.setAfterpayUserAgentString() = apply {
+    settings.userAgentString += " Afterpay-Android-SDK/${BuildConfig.AfterpayLibraryVersion}"
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
@@ -14,12 +14,12 @@ import android.webkit.WebView
 import android.webkit.WebViewClient
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
-import com.afterpay.android.BuildConfig
 import com.afterpay.android.CancellationStatus
 import com.afterpay.android.R
 import com.afterpay.android.internal.getCheckoutUrlExtra
 import com.afterpay.android.internal.putCancellationStatusExtra
 import com.afterpay.android.internal.putOrderTokenExtra
+import com.afterpay.android.internal.setAfterpayUserAgentString
 
 internal class AfterpayCheckoutActivity : AppCompatActivity() {
 
@@ -31,8 +31,6 @@ internal class AfterpayCheckoutActivity : AppCompatActivity() {
             "portal.clearpay.co.uk",
             "portal.sandbox.clearpay.co.uk"
         )
-
-        const val versionHeader = "${BuildConfig.AfterpayLibraryVersion}-android"
     }
 
     private lateinit var webView: WebView
@@ -45,6 +43,7 @@ internal class AfterpayCheckoutActivity : AppCompatActivity() {
         window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 
         webView = findViewById<WebView>(R.id.afterpay_webView).apply {
+            setAfterpayUserAgentString()
             settings.javaScriptEnabled = true
             settings.setSupportMultipleWindows(true)
             webViewClient = AfterpayWebViewClient(
@@ -77,7 +76,7 @@ internal class AfterpayCheckoutActivity : AppCompatActivity() {
             ?: return finish(CancellationStatus.NO_CHECKOUT_URL)
 
         if (validCheckoutUrls.contains(Uri.parse(checkoutUrl).host)) {
-            webView.loadUrl(checkoutUrl, mapOf("X-Afterpay-SDK" to versionHeader))
+            webView.loadUrl(checkoutUrl)
         } else {
             finish(CancellationStatus.INVALID_CHECKOUT_URL)
         }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
@@ -36,6 +36,7 @@ import com.afterpay.android.internal.ShippingOptionMessage
 import com.afterpay.android.internal.getCheckoutV2OptionsExtra
 import com.afterpay.android.internal.putCancellationStatusExtra
 import com.afterpay.android.internal.putOrderTokenExtra
+import com.afterpay.android.internal.setAfterpayUserAgentString
 import kotlinx.serialization.decodeFromString
 import kotlinx.serialization.encodeToString
 import kotlinx.serialization.json.Json
@@ -67,6 +68,7 @@ internal class AfterpayCheckoutV2Activity : AppCompatActivity() {
         val frameLayout = findViewById<FrameLayout>(R.id.afterpay_webView_frame_layout)
 
         bootstrapWebView.apply {
+            setAfterpayUserAgentString()
             settings.javaScriptEnabled = true
             settings.javaScriptCanOpenWindowsAutomatically = true
             settings.setSupportMultipleWindows(true)
@@ -221,6 +223,7 @@ private class BootstrapWebChromeClient(
         resultMsg: Message?
     ): Boolean {
         val webView = WebView(context)
+        webView.setAfterpayUserAgentString()
         webView.visibility = INVISIBLE
         webView.settings.javaScriptEnabled = true
         webView.settings.setSupportMultipleWindows(true)

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayWidgetView.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayWidgetView.kt
@@ -16,6 +16,7 @@ import androidx.annotation.RequiresApi
 import com.afterpay.android.Afterpay
 import com.afterpay.android.R
 import com.afterpay.android.internal.Configuration
+import com.afterpay.android.internal.setAfterpayUserAgentString
 import com.afterpay.android.model.Money
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -107,6 +108,7 @@ class AfterpayWidgetView @JvmOverloads constructor(
         onError: (String) -> Unit,
         onPageFinished: () -> Unit
     ) {
+        setAfterpayUserAgentString()
         @SuppressLint("SetJavaScriptEnabled")
         settings.javaScriptEnabled = true
         settings.domStorageEnabled = true


### PR DESCRIPTION
All web views that load resources from Afterpay systems should now identify themselves using a custom user agent string.