### PR TITLE
Add warning about setting `popupOriginUrl`

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,11 @@ class ExampleActivity: Activity {
 
 ### Launching the Checkout (v2)
 
-Launch the Afterpay checkout v2 flow by starting the intent provided by the SDK for the given options. For more information on express checkout, including the available options and callbacks, please check the [API reference][express-checkout].
+Launch the Afterpay checkout v2 flow by starting the intent provided by the SDK for the given options. 
+
+> When creating a checkout token, `popupOriginUrl` must be set to `https://static.afterpay.com`. The SDK’s example merchant server sets the parameter [here](https://github.com/afterpay/sdk-example-server/blob/master/src/routes/checkout.ts#L28). See more at by checking the [API reference][express-checkout]. Failing to do so will cause undefined behavior.
+
+For more information on express checkout, including the available options and callbacks, please check the [API reference][express-checkout].
 
 ```kotlin
 class ExampleActivity: Activity {

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ class ExampleActivity: Activity {
 
 Launch the Afterpay checkout v2 flow by starting the intent provided by the SDK for the given options. 
 
-> When creating a checkout token, `popupOriginUrl` must be set to `https://static.afterpay.com`. The SDK’s example merchant server sets the parameter [here](https://github.com/afterpay/sdk-example-server/blob/master/src/routes/checkout.ts#L28). See more at by checking the [API reference][express-checkout]. Failing to do so will cause undefined behavior.
+> When creating a checkout token, `popupOriginUrl` must be set to `https://static.afterpay.com`. The SDK’s example merchant server sets the parameter [here](https://github.com/afterpay/sdk-example-server/blob/master/src/routes/checkout.ts#L28). See the [API reference][express-checkout] for more details! Failing to do so will cause undefined behavior.
 
 For more information on express checkout, including the available options and callbacks, please check the [API reference][express-checkout].
 


### PR DESCRIPTION
This must be set when the merchant's API fetches a checkout token. If it doesn't, things get awkward. The iOS readme briefly mentioned it, but now elaborates on it and provides a link to the code where the example merchant API does it.
