### PR TITLE
Fix: ensure that price breakdown badge doesn't span collapsed string

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -124,13 +124,21 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
         textView.apply {
             text = SpannableStringBuilder().apply {
                 if (instalment is AfterpayInstalment.NotAvailable) {
-                    append(" ", CenteredImageSpan(drawable), Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                    append(
+                        "afterpay",
+                        CenteredImageSpan(drawable),
+                        Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+                    )
                     append(" ")
                     append(content.text)
                 } else {
                     append(content.text)
                     append(" ")
-                    append(" ", CenteredImageSpan(drawable), Spannable.SPAN_INCLUSIVE_EXCLUSIVE)
+                    append(
+                        "afterpay",
+                        CenteredImageSpan(drawable),
+                        Spannable.SPAN_INCLUSIVE_EXCLUSIVE
+                    )
                 }
                 append(" ")
                 append(


### PR DESCRIPTION
Badge is disappearing from the price breakdown view under specific conditions:

- price breakdown is of a width where all appended text after badge wraps to the next line
- instalment is available

## Summary of Changes

- Changed price breakdown appended text to non collapsable text

## Items of Note

The badge (a drawable) spans a space which will collapse when at the end of a line therefore hiding the badge.
Changed the text to a non collapsable string ("afterpay"). Also updated this when the instalment is not available even though the scenario shouldn't present itself, this was done for consistency.