### PR TITLE
Price breakdown intro text options

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,6 +313,15 @@ When no payment amount has been set or the merchant account configuration has no
 
 The **Info** link at the end of the component will display a window containing more information about Afterpay for the user.
 
+#### Configuring the Price Breakdown
+
+Setting the `paymentBreakdown.introText` value will modify opening word.
+This can be set to any of the following where OR is default:
+
+```
+paymentBreakdown.introText = AfterpayIntroText.OR|NONE|PAY|IN|PAY_IN
+```
+
 ## Security
 
 To limit the possibility of a man-in-the-middle attack during the checkout process, certificate pinning can be configured for the Afterpay portal. Please refer to the Android [Network Security Configuration][network-config] documentation for more information.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Setting the `paymentBreakdown.introText` value will modify the opening word(s).
 This can be set to any of the following where OR is default:
 
 ```
-paymentBreakdown.introText = AfterpayIntroText.OR|NONE|PAY|IN|PAY_IN
+paymentBreakdown.introText = AfterpayIntroText.OR|NONE|MAKE|PAY|IN|PAY_IN
 ```
 
 ## Security

--- a/README.md
+++ b/README.md
@@ -315,7 +315,7 @@ The **Info** link at the end of the component will display a window containing m
 
 #### Configuring the Price Breakdown
 
-Setting the `paymentBreakdown.introText` value will modify opening word.
+Setting the `paymentBreakdown.introText` value will modify the opening word(s).
 This can be set to any of the following where OR is default:
 
 ```

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
@@ -1,0 +1,17 @@
+package com.afterpay.android.view
+
+import com.afterpay.android.R
+
+enum class AfterpayIntroText(val text: Int) {
+    NONE(R.string.afterpay_price_breakdown_string_empty),
+    PAY(R.string.afterpay_price_breakdown_intro_pay),
+    IN(R.string.afterpay_price_breakdown_intro_in),
+    OR(R.string.afterpay_price_breakdown_intro_or),
+    PAY_IN(R.string.afterpay_price_breakdown_intro_pay_in);
+
+    internal companion object {
+
+        @JvmField
+        val DEFAULT = AfterpayIntroText.OR
+    }
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
@@ -2,7 +2,7 @@ package com.afterpay.android.view
 
 import com.afterpay.android.R
 
-enum class AfterpayIntroText(val text: Int) {
+enum class AfterpayIntroText(val resourceID: Int) {
     NONE(R.string.afterpay_price_breakdown_string_empty),
     PAY(R.string.afterpay_price_breakdown_intro_pay),
     IN(R.string.afterpay_price_breakdown_intro_in),

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
@@ -3,7 +3,8 @@ package com.afterpay.android.view
 import com.afterpay.android.R
 
 enum class AfterpayIntroText(val resourceID: Int) {
-    NONE(R.string.afterpay_price_breakdown_string_empty),
+    NONE(R.string.afterpay_price_breakdown_intro_none),
+    MAKE(R.string.afterpay_price_breakdown_intro_make),
     PAY(R.string.afterpay_price_breakdown_intro_pay),
     IN(R.string.afterpay_price_breakdown_intro_in),
     OR(R.string.afterpay_price_breakdown_intro_or),

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -162,12 +162,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             Content(
                 text = String.format(
                     resources.getString(R.string.afterpay_price_breakdown_total_cost),
-                    resources.getString(introText.text).toLowerCase(),
+                    resources.getString(introText.resourceID).toLowerCase(),
                     afterpay.instalmentAmount
                 ),
                 description = String.format(
                     resources.getString(R.string.afterpay_price_breakdown_total_cost_description),
-                    resources.getString(introText.text),
+                    resources.getString(introText.resourceID),
                     afterpay.instalmentAmount
                 )
             )

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -47,6 +47,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             updateText()
         }
 
+    var introText: AfterpayIntroText = AfterpayIntroText.DEFAULT
+        set(value) {
+            field = value
+            updateText()
+        }
+
     private val textView: TextView = TextView(context).apply {
         setTextColor(context.resolveColorAttr(android.R.attr.textColorPrimary))
         setLinkTextColor(context.resolveColorAttr(android.R.attr.textColorSecondary))
@@ -156,10 +162,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             Content(
                 text = String.format(
                     resources.getString(R.string.afterpay_price_breakdown_total_cost),
+                    resources.getString(introText.text).toLowerCase(),
                     afterpay.instalmentAmount
                 ),
                 description = String.format(
                     resources.getString(R.string.afterpay_price_breakdown_total_cost_description),
+                    resources.getString(introText.text),
                     afterpay.instalmentAmount
                 )
             )

--- a/afterpay/src/main/res/values-en-rGB/strings.xml
+++ b/afterpay/src/main/res/values-en-rGB/strings.xml
@@ -6,7 +6,7 @@
 
     <string name="afterpay_badge_content_description" translatable="true">Clear pay</string>
 
-    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">Or four interest free payments of %1$s with Clear pay</string>
+    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">%1$sfour interest free payments of %2$s with Clear pay</string>
     <string name="afterpay_price_breakdown_limit_description" translatable="true">Clear pay available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_upper_limit_description" translatable="true">Clear pay available for orders up to %1$s</string>
     <string name="afterpay_price_breakdown_no_configuration_description" translatable="true">Or pay with Clear pay</string>

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -9,8 +9,8 @@
 
     <string name="afterpay_badge_content_description" translatable="true">After pay</string>
 
-    <string name="afterpay_price_breakdown_total_cost" translatable="false">or 4 interest-free payments of %1$s with</string>
-    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">Or four interest free payments of %1$s with After pay</string>
+    <string name="afterpay_price_breakdown_total_cost" translatable="false">%1$s4 interest-free payments of %2$s with</string>
+    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">%1$sfour interest free payments of %2$s with After pay</string>
     <string name="afterpay_price_breakdown_limit" translatable="false">available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_limit_description" translatable="true">After pay available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_upper_limit" translatable="false">available for orders up to %1$s</string>
@@ -18,6 +18,12 @@
     <string name="afterpay_price_breakdown_no_configuration" translatable="false">or pay with</string>
     <string name="afterpay_price_breakdown_no_configuration_description" translatable="true">Or pay with After pay</string>
     <string name="afterpay_price_breakdown_info_link" translatable="false">Info</string>
+
+    <string name="afterpay_price_breakdown_string_empty" translatable="false"></string>
+    <string name="afterpay_price_breakdown_intro_pay" translatable="false">Pay\u0020</string>
+    <string name="afterpay_price_breakdown_intro_in" translatable="false">In\u0020</string>
+    <string name="afterpay_price_breakdown_intro_or" translatable="false">Or\u0020</string>
+    <string name="afterpay_price_breakdown_intro_pay_in" translatable="false">Pay In\u0020</string>
 
     <string name="afterpay_payment_button_content_description" translatable="true">Pay now with After pay</string>
 </resources>

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -19,7 +19,8 @@
     <string name="afterpay_price_breakdown_no_configuration_description" translatable="true">Or pay with After pay</string>
     <string name="afterpay_price_breakdown_info_link" translatable="false">Info</string>
 
-    <string name="afterpay_price_breakdown_string_empty" translatable="false"></string>
+    <string name="afterpay_price_breakdown_intro_none" translatable="false"></string>
+    <string name="afterpay_price_breakdown_intro_make" translatable="false">Make\u0020</string>
     <string name="afterpay_price_breakdown_intro_pay" translatable="false">Pay\u0020</string>
     <string name="afterpay_price_breakdown_intro_in" translatable="false">In\u0020</string>
     <string name="afterpay_price_breakdown_intro_or" translatable="false">Or\u0020</string>

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -16,6 +16,7 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
+import com.afterpay.android.view.AfterpayIntroText
 import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
@@ -62,6 +63,7 @@ class ShoppingFragment : Fragment() {
 
         val totalCost = view.findViewById<TextView>(R.id.shopping_totalCost)
         val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
+        afterpayBreakdown.introText = AfterpayIntroText.PAY_IN
 
         lifecycleScope.launchWhenCreated {
             viewModel.state.collectLatest { state ->


### PR DESCRIPTION
Allow for the modification of intro text on the price breakdown.

## Summary of Changes
- Added enum class: `AfterpayIntroText`
- Added intro text options to string resources
- Added local `introText` to `AfterpayPriceBreakdown` class
- Set content to use `introText` when `AfterpayInstalment` is available
- Added documentation

- [x] Documentation is changed or added.

## Screenshots

<details>
<summary>Make</summary>

![Screen Shot 2021-08-24 at 12 33 07 pm](https://user-images.githubusercontent.com/76413218/130547573-1c62b8ad-5a58-497d-afe5-c0dbb41b9bc6.png)
</details>

<details>
<summary>None</summary>

![Screen Shot 2021-08-24 at 12 47 17 pm](https://user-images.githubusercontent.com/76413218/130547813-605e7d7c-1d39-427f-9614-48d3e526a271.png)
</details>

<details>
<summary>Pay In</summary>

![Screen Shot 2021-08-24 at 12 32 31 pm](https://user-images.githubusercontent.com/76413218/130547881-5c015a0a-4502-4dc8-89b6-f8dc940998a6.png)
</details>

## Notes 
This change only allows for lowercased options of the intro text. This means this feature does not yet have parity with other sdks and libraries (react-native and global library)