### PR TITLE
clean up template string for price breakdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,13 +315,18 @@ The **Info** link at the end of the component will display a window containing m
 
 #### Configuring the Price Breakdown
 
-Setting the `paymentBreakdown.introText` value will modify the opening word(s).
-Options are in lowercase unless suffixed with `_TITLE` where they will be title case.
-This can be set to any of the following where OR is default:
+##### Intro Text
+Setting `introText` is optional, will default to `OR` and must be of type `AfterpayIntroText`.
 
+Can be any of `OR`, `OR_TITLE`, `MAKE`, `MAKE_TITLE`, `PAY`, `PAY_TITLE`, `IN`, `IN_TITLE`, `PAY_IN`, `PAY_IN_TITLE` or `EMPTY` (no intro text).
+Intro text will be rendered lowercase unless using an option suffixed with `_TITLE` in which case title case will be rendered.
+
+```kotlin
+let priceBreakdownView = PriceBreakdownView()
+priceBreakdownView.introText = AfterpayIntroText.MAKE_TITLE
 ```
-paymentBreakdown.introText = AfterpayIntroText.OR|OR_TITLE|MAKE|MAKE_TITLE|PAY|PAY_TITLE|IN|IN_TITLE|PAY_IN|PAY_IN_TITLE|NONE
-```
+
+Given the above, the price breakdown text will be rendered `Make 4 interest-free payments of $##.##`
 
 ## Security
 

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayIntroText.kt
@@ -3,7 +3,7 @@ package com.afterpay.android.view
 import com.afterpay.android.R
 
 enum class AfterpayIntroText(val resourceID: Int) {
-    NONE(R.string.afterpay_price_breakdown_intro_none),
+    EMPTY(R.string.afterpay_price_breakdown_intro_empty),
     MAKE_TITLE(R.string.afterpay_price_breakdown_intro_make_title),
     MAKE(R.string.afterpay_price_breakdown_intro_make),
     PAY_TITLE(R.string.afterpay_price_breakdown_intro_pay_title),

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -163,12 +163,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
                     resources.getString(R.string.afterpay_price_breakdown_total_cost),
                     resources.getString(introText.resourceID),
                     afterpay.instalmentAmount
-                ),
+                ).trim(),
                 description = String.format(
                     resources.getString(R.string.afterpay_price_breakdown_total_cost_description),
                     resources.getString(introText.resourceID),
                     afterpay.instalmentAmount
-                )
+                ).trim()
             )
         is AfterpayInstalment.NotAvailable ->
             if (afterpay.minimumAmount != null)

--- a/afterpay/src/main/res/values-en-rGB/strings.xml
+++ b/afterpay/src/main/res/values-en-rGB/strings.xml
@@ -6,7 +6,7 @@
 
     <string name="afterpay_badge_content_description" translatable="true">Clear pay</string>
 
-    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">%1$sfour interest free payments of %2$s with Clear pay</string>
+    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">%1$s four interest free payments of %2$s with Clear pay</string>
     <string name="afterpay_price_breakdown_limit_description" translatable="true">Clear pay available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_upper_limit_description" translatable="true">Clear pay available for orders up to %1$s</string>
     <string name="afterpay_price_breakdown_no_configuration_description" translatable="true">Or pay with Clear pay</string>

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -9,8 +9,8 @@
 
     <string name="afterpay_badge_content_description" translatable="true">After pay</string>
 
-    <string name="afterpay_price_breakdown_total_cost" translatable="false">%1$s4 interest-free payments of %2$s with</string>
-    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">%1$sfour interest free payments of %2$s with After pay</string>
+    <string name="afterpay_price_breakdown_total_cost" translatable="false">%1$s 4 interest-free payments of %2$s with</string>
+    <string name="afterpay_price_breakdown_total_cost_description" translatable="true">%1$s four interest free payments of %2$s with After pay</string>
     <string name="afterpay_price_breakdown_limit" translatable="false">available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_limit_description" translatable="true">After pay available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_upper_limit" translatable="false">available for orders up to %1$s</string>
@@ -20,17 +20,17 @@
     <string name="afterpay_price_breakdown_info_link" translatable="false">Info</string>
 
     <!--  Intro Text Options  -->
-    <string name="afterpay_price_breakdown_intro_none" translatable="false"></string>
-    <string name="afterpay_price_breakdown_intro_make_title" translatable="false">Make\u0020</string>
-    <string name="afterpay_price_breakdown_intro_make" translatable="false">make\u0020</string>
-    <string name="afterpay_price_breakdown_intro_pay_title" translatable="false">Pay\u0020</string>
-    <string name="afterpay_price_breakdown_intro_pay" translatable="false">pay\u0020</string>
-    <string name="afterpay_price_breakdown_intro_in_title" translatable="false">In\u0020</string>
-    <string name="afterpay_price_breakdown_intro_in" translatable="false">in\u0020</string>
-    <string name="afterpay_price_breakdown_intro_or_title" translatable="false">Or\u0020</string>
-    <string name="afterpay_price_breakdown_intro_or" translatable="false">or\u0020</string>
-    <string name="afterpay_price_breakdown_intro_pay_in_title" translatable="false">Pay in\u0020</string>
-    <string name="afterpay_price_breakdown_intro_pay_in" translatable="false">pay in\u0020</string>
+    <string name="afterpay_price_breakdown_intro_empty" translatable="false"></string>
+    <string name="afterpay_price_breakdown_intro_make_title" translatable="false">Make</string>
+    <string name="afterpay_price_breakdown_intro_make" translatable="false">make</string>
+    <string name="afterpay_price_breakdown_intro_pay_title" translatable="false">Pay</string>
+    <string name="afterpay_price_breakdown_intro_pay" translatable="false">pay</string>
+    <string name="afterpay_price_breakdown_intro_in_title" translatable="false">In</string>
+    <string name="afterpay_price_breakdown_intro_in" translatable="false">in</string>
+    <string name="afterpay_price_breakdown_intro_or_title" translatable="false">Or</string>
+    <string name="afterpay_price_breakdown_intro_or" translatable="false">or</string>
+    <string name="afterpay_price_breakdown_intro_pay_in_title" translatable="false">Pay in</string>
+    <string name="afterpay_price_breakdown_intro_pay_in" translatable="false">pay in</string>
 
     <string name="afterpay_payment_button_content_description" translatable="true">Pay now with After pay</string>
 </resources>


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- add a space to `afterpay_price_breakdown_total_cost_description` and `afterpay_price_breakdown_total_cost` for better readability
- removed the space from each of the intro text options
- make sure that the formatted string is trimmed
- change NONE intro text name to EMPTY to better match iOS SDK
- update README with easier to understand language

See screenshots for a comparison alignment of empty intro text and "pay in" intro text.

|EMPTY|PAY_IN|
|----|----|
|![Screenshot_1630627730](https://user-images.githubusercontent.com/76413218/131931553-271dcadd-d4d4-407a-894f-6ca2293ab35d.png)|![Screenshot_1630627754](https://user-images.githubusercontent.com/76413218/131931557-32928074-6a8a-4328-aa73-e5d24edf1d87.png)|
