### PR TITLE
Fix typo in shell command to set animation scale

### DIFF
--- a/example/src/androidTest/kotlin/com/example/afterpay/DisableAnimationsRule.kt
+++ b/example/src/androidTest/kotlin/com/example/afterpay/DisableAnimationsRule.kt
@@ -9,7 +9,7 @@ import java.io.IOException
 
 private const val SHELL_COMMAND = "settings put global %s %d"
 private const val TRANSITION_ANIMATION_SCALE = "transition_animation_scale"
-private const val WINDOW_ANIMATION_SCALE = "window_animation_sc"
+private const val WINDOW_ANIMATION_SCALE = "window_animation_scale"
 private const val ANIMATOR_DURATION = "animator_duration_scale"
 
 class DisableAnimationsRule : TestRule {


### PR DESCRIPTION
## Summary of Changes

Fixed a typo in the shell command used by the `DisableAnimationsRule` to set animation scale.