### PR TITLE
Fix: Add missing `ShippingAddress` properties

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingAddress.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingAddress.kt
@@ -4,6 +4,9 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class ShippingAddress(
+    val name: String?,
+    val address1: String?,
+    val address2: String?,
     val countryCode: String?,
     val postcode: String?,
     val phoneNumber: String?,


### PR DESCRIPTION
These properties, while [undocumented](https://developers.afterpay.com/afterpay-online/reference/integrated-shipping-2), have been [requested by consumers of the iOS SDK](https://github.com/afterpay/sdk-ios/issues/186), and have therefore been mirrored here.

## Summary of Changes

- Add `name`, `address1`, `address2` properties to `ShippingAddress`
