### PR TITLE
Allow for shipping options to be updated upon selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,7 +145,10 @@ class ExampleActivity: Activity {
                 TODO("Use the address to form shipping options and pass to completion")
             }
 
-            override fun shippingOptionDidChange(shippingOption: ShippingOption) {
+            override fun shippingOptionDidChange(
+                shippingOption: ShippingOption,
+                onProvideShippingOptionUpdate: (ShippingOptionUpdateResult?) -> Unit
+            ) {
                 TODO("Optionally update your application model with the selected shipping option")
             }
         })

--- a/afterpay/src/main/kotlin/com/afterpay/android/AfterpayCheckoutV2Handler.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/AfterpayCheckoutV2Handler.kt
@@ -15,6 +15,6 @@ interface AfterpayCheckoutV2Handler {
 
     fun shippingOptionDidChange(
         shippingOption: ShippingOption,
-        onProvideShippingOption: (ShippingOptionUpdateResult) -> Unit
+        onProvideShippingOption: (ShippingOptionUpdateResult?) -> Unit
     )
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/AfterpayCheckoutV2Handler.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/AfterpayCheckoutV2Handler.kt
@@ -2,6 +2,7 @@ package com.afterpay.android
 
 import com.afterpay.android.model.ShippingAddress
 import com.afterpay.android.model.ShippingOption
+import com.afterpay.android.model.ShippingOptionUpdateResult
 import com.afterpay.android.model.ShippingOptionsResult
 
 interface AfterpayCheckoutV2Handler {
@@ -12,5 +13,8 @@ interface AfterpayCheckoutV2Handler {
         onProvideShippingOptions: (ShippingOptionsResult) -> Unit
     )
 
-    fun shippingOptionDidChange(shippingOption: ShippingOption)
+    fun shippingOptionDidChange(
+        shippingOption: ShippingOption,
+        onProvideShippingOption: (ShippingOptionUpdateResult) -> Unit
+    )
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/AfterpayCheckoutV2Options.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/AfterpayCheckoutV2Options.kt
@@ -6,9 +6,11 @@ import android.os.Parcelable
 data class AfterpayCheckoutV2Options(
     val pickup: Boolean? = null,
     val buyNow: Boolean? = null,
-    val shippingOptionRequired: Boolean? = null
+    val shippingOptionRequired: Boolean? = null,
+    val enableSingleShippingOptionUpdate: Boolean? = null
 ) : Parcelable {
     constructor(parcel: Parcel) : this(
+        parcel.readValue(Boolean::class.java.classLoader) as? Boolean,
         parcel.readValue(Boolean::class.java.classLoader) as? Boolean,
         parcel.readValue(Boolean::class.java.classLoader) as? Boolean,
         parcel.readValue(Boolean::class.java.classLoader) as? Boolean
@@ -18,6 +20,7 @@ data class AfterpayCheckoutV2Options(
         parcel.writeValue(pickup)
         parcel.writeValue(buyNow)
         parcel.writeValue(shippingOptionRequired)
+        parcel.writeValue(enableSingleShippingOptionUpdate)
     }
 
     override fun describeContents(): Int {

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutMessage.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutMessage.kt
@@ -37,7 +37,7 @@ internal sealed class AfterpayCheckoutMessage {
             is ShippingOptionUpdateErrorResult -> CheckoutErrorMessage(meta, result.error.name)
             is ShippingOptionUpdateSuccessResult -> ShippingOptionUpdateMessage(
                 meta,
-                result.shippingOptions
+                result.shippingOptionUpdate
             )
         }
     }
@@ -82,7 +82,7 @@ internal data class ShippingOptionMessage(
 @SerialName("onShippingOptionUpdateChange")
 internal data class ShippingOptionUpdateMessage(
     override val meta: AfterpayCheckoutMessageMeta,
-    val payload: ShippingOptionUpdate
+    val payload: ShippingOptionUpdate?
 ) : AfterpayCheckoutMessage()
 
 @Serializable

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutMessage.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutMessage.kt
@@ -2,6 +2,10 @@ package com.afterpay.android.internal
 
 import com.afterpay.android.model.ShippingAddress
 import com.afterpay.android.model.ShippingOption
+import com.afterpay.android.model.ShippingOptionUpdate
+import com.afterpay.android.model.ShippingOptionUpdateErrorResult
+import com.afterpay.android.model.ShippingOptionUpdateResult
+import com.afterpay.android.model.ShippingOptionUpdateSuccessResult
 import com.afterpay.android.model.ShippingOptionsErrorResult
 import com.afterpay.android.model.ShippingOptionsResult
 import com.afterpay.android.model.ShippingOptionsSuccessResult
@@ -24,6 +28,17 @@ internal sealed class AfterpayCheckoutMessage {
         ): AfterpayCheckoutMessage = when (result) {
             is ShippingOptionsErrorResult -> CheckoutErrorMessage(meta, result.error.name)
             is ShippingOptionsSuccessResult -> ShippingOptionsMessage(meta, result.shippingOptions)
+        }
+
+        fun fromShippingOptionUpdateResult(
+            result: ShippingOptionUpdateResult,
+            meta: AfterpayCheckoutMessageMeta
+        ): AfterpayCheckoutMessage = when (result) {
+            is ShippingOptionUpdateErrorResult -> CheckoutErrorMessage(meta, result.error.name)
+            is ShippingOptionUpdateSuccessResult -> ShippingOptionUpdateMessage(
+                meta,
+                result.shippingOptions
+            )
         }
     }
 }
@@ -61,6 +76,13 @@ internal data class ShippingAddressMessage(
 internal data class ShippingOptionMessage(
     override val meta: AfterpayCheckoutMessageMeta,
     val payload: ShippingOption
+) : AfterpayCheckoutMessage()
+
+@Serializable
+@SerialName("onShippingOptionUpdateChange")
+internal data class ShippingOptionUpdateMessage(
+    override val meta: AfterpayCheckoutMessageMeta,
+    val payload: ShippingOptionUpdate
 ) : AfterpayCheckoutMessage()
 
 @Serializable

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutMessage.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutMessage.kt
@@ -31,7 +31,7 @@ internal sealed class AfterpayCheckoutMessage {
         }
 
         fun fromShippingOptionUpdateResult(
-            result: ShippingOptionUpdateResult,
+            result: ShippingOptionUpdateResult?,
             meta: AfterpayCheckoutMessageMeta
         ): AfterpayCheckoutMessage = when (result) {
             is ShippingOptionUpdateErrorResult -> CheckoutErrorMessage(meta, result.error.name)
@@ -39,6 +39,7 @@ internal sealed class AfterpayCheckoutMessage {
                 meta,
                 result.shippingOptionUpdate
             )
+            null -> EmptyPayloadMessage(meta)
         }
     }
 }
@@ -90,4 +91,10 @@ internal data class ShippingOptionUpdateMessage(
 internal data class ShippingOptionsMessage(
     override val meta: AfterpayCheckoutMessageMeta,
     val payload: List<ShippingOption>
+) : AfterpayCheckoutMessage()
+
+@Serializable
+@SerialName("onEmptyPayload")
+internal data class EmptyPayloadMessage(
+    override val meta: AfterpayCheckoutMessageMeta
 ) : AfterpayCheckoutMessage()

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutV2.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayCheckoutV2.kt
@@ -12,7 +12,8 @@ internal data class AfterpayCheckoutV2(
     val version: String,
     val pickup: Boolean?,
     val buyNow: Boolean?,
-    val shippingOptionRequired: Boolean?
+    val shippingOptionRequired: Boolean?,
+    val checkoutRedesignForced: Boolean?
 ) {
     constructor(
         token: String,
@@ -25,6 +26,7 @@ internal data class AfterpayCheckoutV2(
         version = "${BuildConfig.AfterpayLibraryVersion}-android",
         pickup = options.pickup,
         buyNow = options.buyNow,
-        shippingOptionRequired = options.shippingOptionRequired
+        shippingOptionRequired = options.shippingOptionRequired,
+        checkoutRedesignForced = options.enableSingleShippingOptionUpdate
     )
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingOptionUpdate.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingOptionUpdate.kt
@@ -1,0 +1,11 @@
+package com.afterpay.android.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class ShippingOptionUpdate(
+    val id: String,
+    var shippingAmount: Money,
+    var orderAmount: Money,
+    var taxAmount: Money?
+)

--- a/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingOptionUpdateResult.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingOptionUpdateResult.kt
@@ -3,7 +3,7 @@ package com.afterpay.android.model
 sealed class ShippingOptionUpdateResult
 
 data class ShippingOptionUpdateSuccessResult(
-    val shippingOptions: ShippingOptionUpdate
+    val shippingOptionUpdate: ShippingOptionUpdate
 ) : ShippingOptionUpdateResult()
 
 data class ShippingOptionUpdateErrorResult(

--- a/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingOptionUpdateResult.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/model/ShippingOptionUpdateResult.kt
@@ -1,0 +1,16 @@
+package com.afterpay.android.model
+
+sealed class ShippingOptionUpdateResult
+
+data class ShippingOptionUpdateSuccessResult(
+    val shippingOptions: ShippingOptionUpdate
+) : ShippingOptionUpdateResult()
+
+data class ShippingOptionUpdateErrorResult(
+    val error: ShippingOptionUpdateError
+) : ShippingOptionUpdateResult()
+
+enum class ShippingOptionUpdateError {
+    SERVICE_UNAVAILABLE,
+    BAD_RESPONSE
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
@@ -317,7 +317,13 @@ private class BootstrapJavascriptInterface(
                             }
                     }
 
-                    is ShippingOptionMessage -> handler.shippingOptionDidChange(message.payload)
+                    is ShippingOptionMessage -> handler.shippingOptionDidChange(message.payload) {
+                        AfterpayCheckoutMessage
+                            .fromShippingOptionUpdateResult(it, message.meta)
+                            .let {
+                                result -> Log.d("testingtag", result.toString())
+                            }
+                    }
 
                     else -> Unit
                 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
@@ -321,7 +321,14 @@ private class BootstrapJavascriptInterface(
                         AfterpayCheckoutMessage
                             .fromShippingOptionUpdateResult(it, message.meta)
                             .let {
-                                result -> Log.d("testingtag", result.toString())
+                                result ->
+                                    Log.d("jscheckout", result.toString())
+                                    "postMessageToCheckout('${json.encodeToString(result)}');"
+                            }
+                            .also { javascript ->
+                                activity.runOnUiThread {
+                                    webView.evaluateJavascript(javascript, null)
+                                }
                             }
                     }
 

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
@@ -320,9 +320,8 @@ private class BootstrapJavascriptInterface(
                     is ShippingOptionMessage -> handler.shippingOptionDidChange(message.payload) {
                         AfterpayCheckoutMessage
                             .fromShippingOptionUpdateResult(it, message.meta)
-                            .let {
-                                result ->
-                                    "postMessageToCheckout('${json.encodeToString(result)}');"
+                            .let { result ->
+                                "postMessageToCheckout('${json.encodeToString(result)}');"
                             }
                             .also { javascript ->
                                 activity.runOnUiThread {

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
@@ -322,7 +322,6 @@ private class BootstrapJavascriptInterface(
                             .fromShippingOptionUpdateResult(it, message.meta)
                             .let {
                                 result ->
-                                    Log.d("jscheckout", result.toString())
                                     "postMessageToCheckout('${json.encodeToString(result)}');"
                             }
                             .also { javascript ->

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -117,6 +117,10 @@ class CheckoutFragment : Fragment() {
                         checkoutHandler.provideTokenResult(command.tokenResult)
                     is Command.ProvideShippingOptionsResult ->
                         checkoutHandler.provideShippingOptionsResult(command.shippingOptionsResult)
+                    is Command.ProvideShippingOptionUpdateResult ->
+                        checkoutHandler.provideShippingOptionUpdateResult(
+                            command.shippingOptionUpdateResult
+                        )
                 }
             }
         }

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -41,7 +41,7 @@ class CheckoutFragment : Fragment() {
     private val checkoutHandler = CheckoutHandler(
         onDidCommenceCheckout = { viewModel.loadCheckoutToken() },
         onShippingAddressDidChange = { viewModel.selectAddress(it) },
-        onShippingOptionDidChange = { }
+        onShippingOptionDidChange = { viewModel.selectShippingOption(it) }
     )
 
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutHandler.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutHandler.kt
@@ -32,16 +32,16 @@ class CheckoutHandler(
     fun provideShippingOptionsResult(shippingOptionsResult: ShippingOptionsResult) =
         onProvideShippingOptions(shippingOptionsResult).also { onProvideShippingOptions = {} }
 
-    private var onProvideShippingOptionUpdate: (ShippingOptionUpdateResult) -> Unit = {}
+    private var onProvideShippingOptionUpdate: (ShippingOptionUpdateResult?) -> Unit = {}
 
     override fun shippingOptionDidChange(
         shippingOption: ShippingOption,
-        onProvideShippingOptionUpdate: (ShippingOptionUpdateResult) -> Unit
+        onProvideShippingOptionUpdate: (ShippingOptionUpdateResult?) -> Unit
     ) = onShippingOptionDidChange(shippingOption).also {
         this.onProvideShippingOptionUpdate = onProvideShippingOptionUpdate
     }
 
-    fun provideShippingOptionUpdateResult(shippingOptionUpdateResult: ShippingOptionUpdateResult) =
+    fun provideShippingOptionUpdateResult(shippingOptionUpdateResult: ShippingOptionUpdateResult?) =
         onProvideShippingOptionUpdate(shippingOptionUpdateResult).also {
             onProvideShippingOptionUpdate = {}
         }

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutHandler.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutHandler.kt
@@ -3,6 +3,8 @@ package com.example.afterpay.checkout
 import com.afterpay.android.AfterpayCheckoutV2Handler
 import com.afterpay.android.model.ShippingAddress
 import com.afterpay.android.model.ShippingOption
+import com.afterpay.android.model.ShippingOptionUpdate
+import com.afterpay.android.model.ShippingOptionUpdateResult
 import com.afterpay.android.model.ShippingOptionsResult
 
 class CheckoutHandler(
@@ -30,6 +32,17 @@ class CheckoutHandler(
     fun provideShippingOptionsResult(shippingOptionsResult: ShippingOptionsResult) =
         onProvideShippingOptions(shippingOptionsResult).also { onProvideShippingOptions = {} }
 
-    override fun shippingOptionDidChange(shippingOption: ShippingOption) =
-        onShippingOptionDidChange(shippingOption)
+    private var onProvideShippingOptionUpdate: (ShippingOptionUpdateResult) -> Unit = {}
+
+    override fun shippingOptionDidChange(
+        shippingOption: ShippingOption,
+        onProvideShippingOptionUpdate: (ShippingOptionUpdateResult) -> Unit
+    ) = onShippingOptionDidChange(shippingOption).also {
+        this.onProvideShippingOptionUpdate = onProvideShippingOptionUpdate
+    }
+
+    fun provideShippingOptionUpdateResult(shippingOptionUpdateResult: ShippingOptionUpdateResult) =
+        onProvideShippingOptionUpdate(shippingOptionUpdateResult).also {
+            onProvideShippingOptionUpdate = {}
+        }
 }

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutHandler.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutHandler.kt
@@ -3,7 +3,6 @@ package com.example.afterpay.checkout
 import com.afterpay.android.AfterpayCheckoutV2Handler
 import com.afterpay.android.model.ShippingAddress
 import com.afterpay.android.model.ShippingOption
-import com.afterpay.android.model.ShippingOptionUpdate
 import com.afterpay.android.model.ShippingOptionUpdateResult
 import com.afterpay.android.model.ShippingOptionsResult
 

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
@@ -59,7 +59,7 @@ class CheckoutViewModel(
         data class ProvideShippingOptionsResult(val shippingOptionsResult: ShippingOptionsResult) :
             Command()
         data class ProvideShippingOptionUpdateResult(
-                val shippingOptionUpdateResult: ShippingOptionUpdateResult
+                val shippingOptionUpdateResult: ShippingOptionUpdateResult?
             ) : Command()
     }
 
@@ -145,7 +145,7 @@ class CheckoutViewModel(
                     "",
                     Money("0.00".toBigDecimal(), currency),
                     Money("50.00".toBigDecimal(), currency),
-                    null
+                    Money("0.00".toBigDecimal(), currency)
                 ),
                 ShippingOption(
                     "priority",
@@ -172,15 +172,21 @@ class CheckoutViewModel(
             }
 
             val currency = Currency.getInstance(configuration.currency)
+            val result: ShippingOptionUpdateResult?
 
-            val updatedShippingOption = ShippingOptionUpdate(
-                "standard",
-                Money("2.00".toBigDecimal(), currency),
-                Money("50.00".toBigDecimal(), currency),
-                null
-            )
+            if (shippingOption.id == "standard") {
+                val updatedShippingOption = ShippingOptionUpdate(
+                    "standard",
+                    Money("0.00".toBigDecimal(), currency),
+                    Money("50.00".toBigDecimal(), currency),
+                    Money("2.00".toBigDecimal(), currency)
+                )
 
-            val result = ShippingOptionUpdateSuccessResult(updatedShippingOption)
+                result = ShippingOptionUpdateSuccessResult(updatedShippingOption)
+            } else {
+                result = null
+            }
+
             commandChannel.trySend(Command.ProvideShippingOptionUpdateResult(result))
         }
     }

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
@@ -102,7 +102,12 @@ class CheckoutViewModel(
             putShippingOptionsRequired(isShippingOptionsRequired)
         }
 
-        val options = AfterpayCheckoutV2Options(isPickup, isBuyNow, isShippingOptionsRequired)
+        val options = AfterpayCheckoutV2Options(
+            isPickup,
+            isBuyNow,
+            isShippingOptionsRequired,
+            enableSingleShippingOptionUpdate = true
+        )
         commandChannel.trySend(Command.ShowAfterpayCheckout(options))
     }
 

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
@@ -59,8 +59,8 @@ class CheckoutViewModel(
         data class ProvideShippingOptionsResult(val shippingOptionsResult: ShippingOptionsResult) :
             Command()
         data class ProvideShippingOptionUpdateResult(
-                val shippingOptionUpdateResult: ShippingOptionUpdateResult?
-            ) : Command()
+            val shippingOptionUpdateResult: ShippingOptionUpdateResult?
+        ) : Command()
     }
 
     private val state = MutableStateFlow(


### PR DESCRIPTION
This PR aims to allow the updating of a single shipping option once it has been selected (for instance updating the tax amount)

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Add a new param to `AfterpayCheckoutV2Options`: `enableSingleShippingOptionUpdate`. This will need to be set to true to use this feature as only the redesigned checkout supports this.
- Add functionality to example app
- Add a new model class: `ShippingOptionUpdate` that only takes `id` and `Money` amounts
- post message to checkout as closure to update shipping option
- send back empty payload if updated shipping option is `nil`

## Items of note
### Breaking changes
- public type alias `ShippingOptionsDidChangeClosure` changes to `ShippingOptionDidChangeClosure` for clarity
- public protocol `CheckoutV2Handler`'s method `shippingOptionDidChange` now takes a second parameter `completion` of type `ShippingOptionCompletion`

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] Documentation is changed or added.
