### PR TITLE
Feature: optional words

### DIFF
--- a/README.md
+++ b/README.md
@@ -324,6 +324,13 @@ Setting `introText` is optional, will default to `OR` and must be of type `After
 Can be any of `OR`, `OR_TITLE`, `MAKE`, `MAKE_TITLE`, `PAY`, `PAY_TITLE`, `IN`, `IN_TITLE`, `PAY_IN`, `PAY_IN_TITLE` or `EMPTY` (no intro text).
 Intro text will be rendered lowercase unless using an option suffixed with `_TITLE` in which case title case will be rendered.
 
+##### Optional Words
+Setting `showInterestFreeText` and / or `showWithText` is optional and is of type `Boolean`.
+
+Both default to true. This will show the text `pay in 4 interest-free payents of $#.##`.
+Setting `showInterestFreeText` to false will remove "interest-free" from the sentence.
+Setting `showWithText` to false will remove the word "with" from the sentence.
+
 ```kotlin
 val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.afterpayPriceBreakdown)
 afterpayBreakdown.introText = AfterpayIntroText.MAKE_TITLE

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayOptionalText.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayOptionalText.kt
@@ -1,0 +1,28 @@
+package com.afterpay.android.view
+
+import com.afterpay.android.R
+
+enum class AfterpayOptionalText(val textResourceID: Int, val descriptionResourceId: Int) {
+    NONE(
+        R.string.afterpay_price_breakdown_available_no_optional,
+        R.string.afterpay_price_breakdown_available_no_optional_description
+    ),
+    INTEREST_FREE(
+        R.string.afterpay_price_breakdown_available_interest,
+        R.string.afterpay_price_breakdown_available_interest_description
+    ),
+    WITH(
+        R.string.afterpay_price_breakdown_available_with,
+        R.string.afterpay_price_breakdown_available_with_description
+    ),
+    INTEREST_FREE_AND_WITH(
+        R.string.afterpay_price_breakdown_available_interest_and_with,
+        R.string.afterpay_price_breakdown_available_interest_and_with_description
+    );
+
+    internal companion object {
+
+        @JvmField
+        val DEFAULT = AfterpayOptionalText.INTEREST_FREE_AND_WITH
+    }
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -52,7 +52,13 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             updateText()
         }
 
-    var optionalText: AfterpayOptionalText = AfterpayOptionalText.DEFAULT
+    var showWithText: Boolean = true
+        set(value) {
+            field = value
+            updateText()
+        }
+
+    var showInterestFreeText: Boolean = true
         set(value) {
             field = value
             updateText()
@@ -163,20 +169,31 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
     }
 
     private fun generateContent(afterpay: AfterpayInstalment): Content = when (afterpay) {
-        is AfterpayInstalment.Available ->
+        is AfterpayInstalment.Available -> {
+            val template: AfterpayOptionalText = if (showInterestFreeText && showWithText) {
+                AfterpayOptionalText.INTEREST_FREE_AND_WITH
+            } else if (showInterestFreeText) {
+                AfterpayOptionalText.INTEREST_FREE_AND_WITH
+            } else if (showWithText) {
+                AfterpayOptionalText.WITH
+            } else {
+                AfterpayOptionalText.NONE
+            }
+
             Content(
                 text = String.format(
-                    resources.getString(optionalText.textResourceID),
+                    resources.getString(template.textResourceID),
                     resources.getString(introText.resourceID),
                     afterpay.instalmentAmount
                 ).trim(),
                 description = String.format(
-                    resources.getString(optionalText.descriptionResourceId),
+                    resources.getString(template.descriptionResourceId),
                     resources.getString(introText.resourceID),
                     afterpay.instalmentAmount,
                     resources.getString(Afterpay.brand.description)
                 ).trim()
             )
+        }
         is AfterpayInstalment.NotAvailable ->
             if (afterpay.minimumAmount != null)
                 Content(

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -52,6 +52,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             updateText()
         }
 
+    var optionalText: AfterpayOptionalText = AfterpayOptionalText.DEFAULT
+        set(value) {
+            field = value
+            updateText()
+        }
+
     private val textView: TextView = TextView(context).apply {
         setTextColor(context.resolveColorAttr(android.R.attr.textColorPrimary))
         setLinkTextColor(context.resolveColorAttr(android.R.attr.textColorSecondary))
@@ -160,12 +166,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
         is AfterpayInstalment.Available ->
             Content(
                 text = String.format(
-                    resources.getString(R.string.afterpay_price_breakdown_total_cost),
+                    resources.getString(optionalText.textResourceID),
                     resources.getString(introText.resourceID),
                     afterpay.instalmentAmount
                 ).trim(),
                 description = String.format(
-                    resources.getString(R.string.afterpay_price_breakdown_total_cost_description),
+                    resources.getString(optionalText.descriptionResourceId),
                     resources.getString(introText.resourceID),
                     afterpay.instalmentAmount,
                     resources.getString(Afterpay.brand.description)

--- a/afterpay/src/main/res/values/strings.xml
+++ b/afterpay/src/main/res/values/strings.xml
@@ -5,14 +5,25 @@
     <string name="afterpay_load_error_cancel" translatable="false">Cancel</string>
     <string name="afterpay_load_error_message" translatable="false">Failed to load %1$s checkout</string>
 
-    <string name="afterpay_price_breakdown_total_cost" translatable="false">%1$s 4 interest-free payments of %2$s with</string>
-    <string name="afterpay_price_breakdown_total_cost_description" translatable="false">%1$s four interest free payments of %2$s with %3$s</string>
+    <!--  Price breakdown templates: Available  -->
+    <string name="afterpay_price_breakdown_available_no_optional" translatable="false">%1$s 4 payments of %2$s</string>
+    <string name="afterpay_price_breakdown_available_no_optional_description" translatable="false">%1$s four payments of %2$s %3$s</string>
+    <string name="afterpay_price_breakdown_available_interest" translatable="false">%1$s 4 interest-free payments of %2$s</string>
+    <string name="afterpay_price_breakdown_available_interest_description" translatable="false">%1$s four interest free payments of %2$s %3$s</string>
+    <string name="afterpay_price_breakdown_available_with" translatable="false">%1$s 4 payments of %2$s with</string>
+    <string name="afterpay_price_breakdown_available_with_description" translatable="false">%1$s four payments of %2$s with %3$s</string>
+    <string name="afterpay_price_breakdown_available_interest_and_with" translatable="false">%1$s 4 interest-free payments of %2$s with</string>
+    <string name="afterpay_price_breakdown_available_interest_and_with_description" translatable="false">%1$s four interest free payments of %2$s with %3$s</string>
+    <!--  Price breakdown templates: Outside limits  -->
     <string name="afterpay_price_breakdown_limit" translatable="false">available for orders between %1$s – %2$s</string>
     <string name="afterpay_price_breakdown_limit_description" translatable="false">%1$s available for orders between %2$s – %3$s</string>
     <string name="afterpay_price_breakdown_upper_limit" translatable="false">available for orders up to %1$s</string>
     <string name="afterpay_price_breakdown_upper_limit_description" translatable="false">%1$s available for orders up to %2$s</string>
+    <!--  Price breakdown templates: No config  -->
     <string name="afterpay_price_breakdown_no_configuration" translatable="false">or pay with</string>
     <string name="afterpay_price_breakdown_no_configuration_description" translatable="false">Or pay with %1$s</string>
+
+    <!--  More info  -->
     <string name="afterpay_price_breakdown_info_link" translatable="false">Info</string>
 
     <!--  Intro Text Options  -->

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -17,7 +17,6 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.afterpay.android.view.AfterpayIntroText
-import com.afterpay.android.view.AfterpayOptionalText
 import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
@@ -65,7 +64,7 @@ class ShoppingFragment : Fragment() {
         val totalCost = view.findViewById<TextView>(R.id.shopping_totalCost)
         val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
         afterpayBreakdown.introText = AfterpayIntroText.PAY_IN
-        afterpayBreakdown.optionalText = AfterpayOptionalText.WITH
+        afterpayBreakdown.showInterestFreeText = false
 
         lifecycleScope.launchWhenCreated {
             viewModel.state.collectLatest { state ->

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.afterpay.android.view.AfterpayIntroText
+import com.afterpay.android.view.AfterpayOptionalText
 import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
@@ -64,6 +65,7 @@ class ShoppingFragment : Fragment() {
         val totalCost = view.findViewById<TextView>(R.id.shopping_totalCost)
         val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
         afterpayBreakdown.introText = AfterpayIntroText.PAY_IN
+        afterpayBreakdown.optionalText = AfterpayOptionalText.WITH
 
         lifecycleScope.launchWhenCreated {
             viewModel.state.collectLatest { state ->


### PR DESCRIPTION
## Summary of Changes

Added two options to the price breakdown component
- `showInterestFreeText`: A boolean that defaults to true and hides the word "interest-free" from the component if set to false
- `showWithText`: A boolean that defaults to true and hides the word "with" from the component if set to false

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] [Documentation](https://github.com/afterpay/sdk-android/tree/feature/optional-words#optional-words) is added.
