### PR TITLE
Fix: instalment breakdown amount when scale of divident is 0

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -1,5 +1,6 @@
 package com.afterpay.android.internal
 
+import android.util.Log
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat
@@ -58,7 +59,8 @@ internal sealed class AfterpayInstalment {
                 )
             }
 
-            val instalment = (totalCost / 4.toBigDecimal()).setScale(2, RoundingMode.HALF_EVEN)
+            val numberOfInstalments = 4.toBigDecimal()
+            val instalment = totalCost.divide(numberOfInstalments, 2, RoundingMode.HALF_EVEN)
             return Available(instalmentAmount = currencyFormatter.format(instalment))
         }
     }

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -1,6 +1,5 @@
 package com.afterpay.android.internal
 
-import android.util.Log
 import java.math.BigDecimal
 import java.math.RoundingMode
 import java.text.DecimalFormat

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentTest.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentTest.kt
@@ -17,6 +17,7 @@ class AfterpayInstalmentTest {
     private val unitedStatesDollar: Currency = Currency.getInstance("USD")
 
     private val oneHundredAndTwenty = 120.toBigDecimal()
+    private val oneHundredAndTwentyOne = 121.toBigDecimal()
 
     @Test
     fun `available instalment in Australia locale`() {
@@ -101,6 +102,31 @@ class AfterpayInstalmentTest {
         assertEquals("£30.00", gbpInstalment.instalmentAmount)
         assertEquals("NZ$30.00", nzdInstalment.instalmentAmount)
         assertEquals("$30.00", usdInstalment.instalmentAmount)
+    }
+
+    /**
+     * This test was added because when using the / character to divide a BigDecimal
+     * it uses the BigDecimal.div extension
+     *
+     * see here: https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/java.math.-big-decimal/div.html
+     *
+     * Relevant section is: The scale of the result is the same as the scale of this (divident)
+     */
+    @Test
+    fun `available instalment when amount is round and odd`() {
+        val locale = Locales.AUSTRALIA
+
+        val audInstalment = availableInstalment(oneHundredAndTwentyOne, australianDollar, locale)
+        val cadInstalment = availableInstalment(oneHundredAndTwentyOne, canadianDollar, locale)
+        val gbpInstalment = availableInstalment(oneHundredAndTwentyOne, poundSterling, locale)
+        val nzdInstalment = availableInstalment(oneHundredAndTwentyOne, newZealandDollar, locale)
+        val usdInstalment = availableInstalment(oneHundredAndTwentyOne, unitedStatesDollar, locale)
+
+        assertEquals("$30.25", audInstalment.instalmentAmount)
+        assertEquals("$30.25 CAD", cadInstalment.instalmentAmount)
+        assertEquals("£30.25", gbpInstalment.instalmentAmount)
+        assertEquals("$30.25 NZD", nzdInstalment.instalmentAmount)
+        assertEquals("$30.25 USD", usdInstalment.instalmentAmount)
     }
 
     private fun availableInstalment(


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Adjust method for calculating instalment amount

## Items of Note
Under certain conditions the instalment amount was calculating incorrectly.
This was due to the [BigDecimal.div extension](https://kotlinlang.org/api/latest/jvm/stdlib/kotlin/java.math.-big-decimal/div.html) being used, which returns the result with scale equal to the scale of the divident.

For example, an amount of `7.00` was giving a result of `2.00`. 

## Submission Checklist

<!--
Please remove items that do not apply and check off those that do.
-->
- [x] Tests are included.
