### PR TITLE
Feature: modal theme and id

### DIFF
--- a/README.md
+++ b/README.md
@@ -348,7 +348,7 @@ The second takes two parameters:
 - `isCbtEnabled`: a `boolean` to indicate if the modal should show the Cross Border Trade details in the modal
 
 **Notes**
-If both `modalId` is set `modalTheme` and `isCbtEnabled` are ignored.
+If `modalId` is set, both `modalTheme` and `isCbtEnabled` are ignored.
 Not all combinations of Locales and CBT are available.
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -339,8 +339,11 @@ afterpayBreakdown.introText = AfterpayIntroText.MAKE_TITLE
 Given the above, the price breakdown text will be rendered `Make 4 interest-free payments of $##.##`
 
 ##### More Info Options
-Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes three parameters:
+Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class has two constructors.
+The first takes a single parameter:
 - `modalId`: a `string` that is the filename of a modal hosted on Afterpay static.
+
+The second takes two parameters:
 - `modalTheme`: an enum of type `AfterpayModalTheme` with the following options: `MINT` (default) and `WHITE`.
 - `isCbtEnabled`: a `boolean` to indicate if the modal should show the Cross Border Trade details in the modal
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ class ExampleActivity: Activity {
 
 ### Launching the Checkout (v2)
 
-Launch the Afterpay checkout v2 flow by starting the intent provided by the SDK for the given options. 
+Launch the Afterpay checkout v2 flow by starting the intent provided by the SDK for the given options.
 
 > When creating a checkout token, `popupOriginUrl` must be set to `https://static.afterpay.com`. The SDK’s example merchant server sets the parameter [here](https://github.com/afterpay/sdk-example-server/blob/master/src/routes/checkout.ts#L28). See the [API reference][express-checkout] for more details! Failing to do so will cause undefined behavior.
 
@@ -199,7 +199,7 @@ class ReceiptFragment : Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         // ...
-        
+
         view.findViewById<AfterpayWidgetView>(R.id.afterpay_widget)
             .init(token, ::onWidgetExternalLink, ::onWidgetUpdate, ::onWidgetError)
     }
@@ -337,6 +337,22 @@ afterpayBreakdown.introText = AfterpayIntroText.MAKE_TITLE
 ```
 
 Given the above, the price breakdown text will be rendered `Make 4 interest-free payments of $##.##`
+
+##### More Info Options
+Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes two parameters:
+- `modalId`: a `string` that is the filename of a modal hosted on Afterpay static
+- `modalTheme`: an enum of type `AfterpayModalTheme` withe the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`. Please note that not all themes are supported by all locales.
+
+If both `modalId` and `modalTheme` are set, `modalId` takes precedence.
+
+```kotlin
+val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.afterpayPriceBreakdown)
+afterpayBreakdown.moreInfoOptions = AfterpayMoreInfoOptions(
+    modalTheme = AfterpayModalTheme.WHITE
+)
+```
+
+Given the above, when clicking the more info "link", the modal that opens will be white in the current locale as set in configuration.
 
 ## Security
 

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Given the above, the price breakdown text will be rendered `Make 4 interest-free
 ##### More Info Options
 Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes three parameters:
 - `modalId`: a `string` that is the filename of a modal hosted on Afterpay static.
-- `modalTheme`: an enum of type `AfterpayModalTheme` withe the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`.
+- `modalTheme`: an enum of type `AfterpayModalTheme` with the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`.
 - `isCBT`: a `boolean` to indicate if the modal should show the CBT details in the modal
 
 **Notes**

--- a/README.md
+++ b/README.md
@@ -347,8 +347,7 @@ The second takes two parameters:
 - `modalTheme`: an enum of type `AfterpayModalTheme` with the following options: `MINT` (default) and `WHITE`.
 - `isCbtEnabled`: a `boolean` to indicate if the modal should show the Cross Border Trade details in the modal
 
-**Notes**
-If `modalId` is set, both `modalTheme` and `isCbtEnabled` are ignored.
+**Note**
 Not all combinations of Locales and CBT are available.
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -339,7 +339,7 @@ afterpayBreakdown.introText = AfterpayIntroText.MAKE_TITLE
 Given the above, the price breakdown text will be rendered `Make 4 interest-free payments of $##.##`
 
 ##### More Info Options
-Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes two parameters:
+Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes three parameters:
 - `modalId`: a `string` that is the filename of a modal hosted on Afterpay static.
 - `modalTheme`: an enum of type `AfterpayModalTheme` withe the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`.
 - `isCBT`: a `boolean` to indicate if the modal should show the CBT details in the modal

--- a/README.md
+++ b/README.md
@@ -341,7 +341,7 @@ Given the above, the price breakdown text will be rendered `Make 4 interest-free
 ##### More Info Options
 Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes three parameters:
 - `modalId`: a `string` that is the filename of a modal hosted on Afterpay static.
-- `modalTheme`: an enum of type `AfterpayModalTheme` with the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`.
+- `modalTheme`: an enum of type `AfterpayModalTheme` with the following options: `MINT` (default) and `WHITE`.
 - `isCBT`: a `boolean` to indicate if the modal should show the CBT details in the modal
 
 **Notes**

--- a/README.md
+++ b/README.md
@@ -342,10 +342,10 @@ Given the above, the price breakdown text will be rendered `Make 4 interest-free
 Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes three parameters:
 - `modalId`: a `string` that is the filename of a modal hosted on Afterpay static.
 - `modalTheme`: an enum of type `AfterpayModalTheme` with the following options: `MINT` (default) and `WHITE`.
-- `isCBT`: a `boolean` to indicate if the modal should show the CBT details in the modal
+- `isCbtEnabled`: a `boolean` to indicate if the modal should show the Cross Border Trade details in the modal
 
 **Notes**
-If both `modalId` is set `modalTheme` and `isCBT` are ignored.
+If both `modalId` is set `modalTheme` and `isCbtEnabled` are ignored.
 Not all combinations of Locales and CBT are available.
 
 ```kotlin

--- a/README.md
+++ b/README.md
@@ -340,10 +340,13 @@ Given the above, the price breakdown text will be rendered `Make 4 interest-free
 
 ##### More Info Options
 Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. This class takes two parameters:
-- `modalId`: a `string` that is the filename of a modal hosted on Afterpay static
-- `modalTheme`: an enum of type `AfterpayModalTheme` withe the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`. Please note that not all themes are supported by all locales.
+- `modalId`: a `string` that is the filename of a modal hosted on Afterpay static.
+- `modalTheme`: an enum of type `AfterpayModalTheme` withe the following options: `DEFAULT`, `DEFAULT_CBT`, `WHITE` and `WHITE_CBT`.
+- `isCBT`: a `boolean` to indicate if the modal should show the CBT details in the modal
 
+**Notes**
 If both `modalId` and `modalTheme` are set, `modalId` takes precedence.
+Not all combinations of Locales and CBT are available.
 
 ```kotlin
 val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.afterpayPriceBreakdown)

--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ Setting `moreInfoOptions` is optional and of type `AfterpayMoreInfoOptions`. Thi
 - `isCBT`: a `boolean` to indicate if the modal should show the CBT details in the modal
 
 **Notes**
-If both `modalId` and `modalTheme` are set, `modalId` takes precedence.
+If both `modalId` is set `modalTheme` and `isCBT` are ignored.
 Not all combinations of Locales and CBT are available.
 
 ```kotlin

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayModalTheme.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayModalTheme.kt
@@ -1,8 +1,6 @@
 package com.afterpay.android.view
 
 enum class AfterpayModalTheme(val slug: String) {
-    DEFAULT(""),
-    DEFAULT_CBT("-cbt"),
-    WHITE("-theme-white"),
-    WHITE_CBT("-theme-white-cbt");
+    MINT(""),
+    WHITE("-theme-white");
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayModalTheme.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayModalTheme.kt
@@ -1,0 +1,8 @@
+package com.afterpay.android.view
+
+enum class AfterpayModalTheme(val slug: String) {
+    DEFAULT(""),
+    DEFAULT_CBT("-cbt"),
+    WHITE("-theme-white"),
+    WHITE_CBT("-theme-white-cbt");
+}

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
@@ -2,9 +2,20 @@ package com.afterpay.android.view
 
 import com.afterpay.android.Afterpay
 
+/**
+ * Setting up options for the more info link in AfterpayPriceBreakdown
+ *
+ * **Notes:**
+ * - If both `modalId` is set, `modalTheme` and `isCbtEnabled` are ignored.
+ * - Not all combinations of Locales and CBT are available.
+ *
+ * @param modalId the filename of a modal hosted on Afterpay static
+ * @param modalTheme the color theme used when displaying the modal
+ * @param isCbtEnabled whether to show the Cross Border Trade details in the modal
+ */
 class AfterpayMoreInfoOptions(
-    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT,
     var modalId: String? = null,
+    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT,
     var isCbtEnabled: Boolean = false
 ) {
     internal fun modalFile(): String {

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
@@ -5,7 +5,7 @@ import com.afterpay.android.Afterpay
 class AfterpayMoreInfoOptions(
     var modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT,
     var modalId: String? = null,
-    var isCBT: Boolean = false
+    var isCbtEnabled: Boolean = false
 ) {
     internal fun modalFile(): String {
         modalId?.let {
@@ -13,7 +13,7 @@ class AfterpayMoreInfoOptions(
         }
 
         val locale = "${Afterpay.locale.language}_${Afterpay.locale.country}"
-        val cbt = if (isCBT) "-cbt" else ""
+        val cbt = if (isCbtEnabled) "-cbt" else ""
         val theme = modalTheme.slug
 
         return "$locale$theme$cbt.html"

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
@@ -2,22 +2,37 @@ package com.afterpay.android.view
 
 import com.afterpay.android.Afterpay
 
-/**
- * Setting up options for the more info link in AfterpayPriceBreakdown
- *
- * **Notes:**
- * - If both `modalId` is set, `modalTheme` and `isCbtEnabled` are ignored.
- * - Not all combinations of Locales and CBT are available.
- *
- * @param modalId the filename of a modal hosted on Afterpay static
- * @param modalTheme the color theme used when displaying the modal
- * @param isCbtEnabled whether to show the Cross Border Trade details in the modal
- */
-class AfterpayMoreInfoOptions(
-    var modalId: String? = null,
-    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT,
-    var isCbtEnabled: Boolean = false
-) {
+class AfterpayMoreInfoOptions {
+    private var modalId: String? = null
+    private var modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT
+    private var isCbtEnabled: Boolean = false
+
+    /**
+     * Set up options for the more info link in AfterpayPriceBreakdown
+     *
+     * @param modalId the filename of a modal hosted on Afterpay static
+     */
+    constructor(modalId: String) {
+        this.modalId = modalId
+    }
+
+    /**
+     * Set up options for the more info link in AfterpayPriceBreakdown
+     *
+     * **Notes:**
+     * - Not all combinations of Locales and CBT are available.
+     *
+     * @param modalTheme the color theme used when displaying the modal
+     * @param isCbtEnabled whether to show the Cross Border Trade details in the modal
+     */
+    constructor(
+        modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT,
+        isCbtEnabled: Boolean = false
+    ) {
+        this.modalTheme = modalTheme
+        this.isCbtEnabled = isCbtEnabled
+    }
+
     internal fun modalFile(): String {
         modalId?.let {
             return "$it.html"

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
@@ -7,13 +7,13 @@ class AfterpayMoreInfoOptions(
     var modalId: String? = null,
     var isCBT: Boolean = false
 ) {
-    internal fun modalFile() : String {
+    internal fun modalFile(): String {
         modalId?.let {
             return "$it.html"
         }
 
         val locale = "${Afterpay.locale.language}_${Afterpay.locale.country}"
-        val cbt = if(isCBT) "-cbt" else ""
+        val cbt = if (isCBT) "-cbt" else ""
         val theme = modalTheme.slug
 
         return "$locale$theme$cbt.html"

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
@@ -3,16 +3,19 @@ package com.afterpay.android.view
 import com.afterpay.android.Afterpay
 
 class AfterpayMoreInfoOptions(
-    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.DEFAULT,
-    var modalId: String? = null
+    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.MINT,
+    var modalId: String? = null,
+    var isCBT: Boolean = false
 ) {
-
-    fun modalFile() : String {
+    internal fun modalFile() : String {
         modalId?.let {
             return "$it.html"
         }
 
         val locale = "${Afterpay.locale.language}_${Afterpay.locale.country}"
-        return "$locale${modalTheme.slug}.html"
+        val cbt = if(isCBT) "-cbt" else ""
+        val theme = modalTheme.slug
+
+        return "$locale$theme$cbt.html"
     }
 }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayMoreInfoOptions.kt
@@ -2,7 +2,7 @@ package com.afterpay.android.view
 
 import com.afterpay.android.Afterpay
 
-class MoreInfoOptions(
+class AfterpayMoreInfoOptions(
     var modalTheme: AfterpayModalTheme = AfterpayModalTheme.DEFAULT,
     var modalId: String? = null
 ) {

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -64,7 +64,7 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             updateText()
         }
 
-    var moreInfoOptions: MoreInfoOptions = MoreInfoOptions()
+    var moreInfoOptions: AfterpayMoreInfoOptions = AfterpayMoreInfoOptions()
         set(value) {
             field = value
             updateText()

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -64,6 +64,10 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             updateText()
         }
 
+    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.DEFAULT
+
+    var modalId: String? = null
+
     private val textView: TextView = TextView(context).apply {
         setTextColor(context.resolveColorAttr(android.R.attr.textColorPrimary))
         setLinkTextColor(context.resolveColorAttr(android.R.attr.textColorSecondary))
@@ -77,8 +81,12 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
     // The terms and conditions are tied to the configured locale on the configuration
     private val infoUrl: String
         get() {
+            modalId?.let {
+                return "https://static.afterpay.com/modal/$modalId.html"
+            }
+
             val locale = "${Afterpay.locale.language}_${Afterpay.locale.country}"
-            return "https://static.afterpay.com/modal/$locale.html"
+            return "https://static.afterpay.com/modal/$locale${modalTheme.slug}.html"
         }
 
     init {

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -64,9 +64,11 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
             updateText()
         }
 
-    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.DEFAULT
-
-    var modalId: String? = null
+    var moreInfoOptions: MoreInfoOptions = MoreInfoOptions()
+        set(value) {
+            field = value
+            updateText()
+        }
 
     private val textView: TextView = TextView(context).apply {
         setTextColor(context.resolveColorAttr(android.R.attr.textColorPrimary))
@@ -81,12 +83,7 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
     // The terms and conditions are tied to the configured locale on the configuration
     private val infoUrl: String
         get() {
-            modalId?.let {
-                return "https://static.afterpay.com/modal/$modalId.html"
-            }
-
-            val locale = "${Afterpay.locale.language}_${Afterpay.locale.country}"
-            return "https://static.afterpay.com/modal/$locale${modalTheme.slug}.html"
+            return "https://static.afterpay.com/modal/${moreInfoOptions.modalFile()}"
         }
 
     init {

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/MoreInfoOptions.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/MoreInfoOptions.kt
@@ -1,0 +1,18 @@
+package com.afterpay.android.view
+
+import com.afterpay.android.Afterpay
+
+class MoreInfoOptions(
+    var modalTheme: AfterpayModalTheme = AfterpayModalTheme.DEFAULT,
+    var modalId: String? = null
+) {
+
+    fun modalFile() : String {
+        modalId?.let {
+            return "$it.html"
+        }
+
+        val locale = "${Afterpay.locale.language}_${Afterpay.locale.country}"
+        return "$locale${modalTheme.slug}.html"
+    }
+}

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -19,6 +19,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.afterpay.android.view.AfterpayIntroText
 import com.afterpay.android.view.AfterpayModalTheme
 import com.afterpay.android.view.AfterpayPriceBreakdown
+import com.afterpay.android.view.MoreInfoOptions
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
 import com.example.afterpay.nav_graph
@@ -66,7 +67,9 @@ class ShoppingFragment : Fragment() {
         val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
         afterpayBreakdown.introText = AfterpayIntroText.PAY_IN
         afterpayBreakdown.showInterestFreeText = false
-        afterpayBreakdown.modalTheme = AfterpayModalTheme.WHITE_CBT
+        afterpayBreakdown.moreInfoOptions = MoreInfoOptions(
+            modalTheme = AfterpayModalTheme.WHITE_CBT
+        )
 
         lifecycleScope.launchWhenCreated {
             viewModel.state.collectLatest { state ->

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -19,7 +19,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.afterpay.android.view.AfterpayIntroText
 import com.afterpay.android.view.AfterpayModalTheme
 import com.afterpay.android.view.AfterpayPriceBreakdown
-import com.afterpay.android.view.MoreInfoOptions
+import com.afterpay.android.view.AfterpayMoreInfoOptions
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
 import com.example.afterpay.nav_graph
@@ -67,8 +67,8 @@ class ShoppingFragment : Fragment() {
         val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
         afterpayBreakdown.introText = AfterpayIntroText.PAY_IN
         afterpayBreakdown.showInterestFreeText = false
-        afterpayBreakdown.moreInfoOptions = MoreInfoOptions(
-            modalTheme = AfterpayModalTheme.WHITE_CBT
+        afterpayBreakdown.moreInfoOptions = AfterpayMoreInfoOptions(
+            modalTheme = AfterpayModalTheme.WHITE
         )
 
         lifecycleScope.launchWhenCreated {

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -17,6 +17,7 @@ import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.afterpay.android.view.AfterpayIntroText
+import com.afterpay.android.view.AfterpayModalTheme
 import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
@@ -65,6 +66,7 @@ class ShoppingFragment : Fragment() {
         val afterpayBreakdown = view.findViewById<AfterpayPriceBreakdown>(R.id.shopping_afterpayPriceBreakdown)
         afterpayBreakdown.introText = AfterpayIntroText.PAY_IN
         afterpayBreakdown.showInterestFreeText = false
+        afterpayBreakdown.modalTheme = AfterpayModalTheme.WHITE_CBT
 
         lifecycleScope.launchWhenCreated {
             viewModel.state.collectLatest { state ->

--- a/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/shopping/ShoppingFragment.kt
@@ -18,8 +18,8 @@ import androidx.recyclerview.widget.ListAdapter
 import androidx.recyclerview.widget.RecyclerView
 import com.afterpay.android.view.AfterpayIntroText
 import com.afterpay.android.view.AfterpayModalTheme
-import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.afterpay.android.view.AfterpayMoreInfoOptions
+import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.example.afterpay.R
 import com.example.afterpay.data.Product
 import com.example.afterpay.nav_graph


### PR DESCRIPTION
## Summary of Changes

This PR aims to allow the "more information" modal to be modified by either a theme option or an id. It also allows for CBT modal. Changes made
- Updated readme
- New class `MoreInfoOptions` that takes `modalTheme`, `modalId` and `isCbtEnabled`
- Updated example app demonstrating implementation

## Items of Note

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

## Submission Checklist

- [x] Documentation is changed or added. (see [More Info Options](https://github.com/afterpay/sdk-android/blob/66713ee63916f240d67cf020af1511c7b0683eb6/README.md#more-info-options))

## Screenshots

All screenshots have been taken with merchant locale set to `en_AU`

<details>
<summary><code>moreInfoOptions</code> not set</summary>

<img src="https://user-images.githubusercontent.com/76413218/151526162-2c49eec2-c75f-44a7-a0bb-37d49fad9725.png" width="500" />
</details>

<details>
<summary>Modal theme white</summary>

<pre><code>
afterpayBreakdown.moreInfoOptions = AfterpayMoreInfoOptions(
    modalTheme = AfterpayModalTheme.WHITE
)
</code></pre>

<img src="https://user-images.githubusercontent.com/76413218/151526929-94fb18aa-b4ef-462f-bbc1-891f59efdbf2.png" width="500" />
</details>

<details>
<summary>Cross border trade enabled</summary>

<pre><code>
afterpayBreakdown.moreInfoOptions = AfterpayMoreInfoOptions(
    isCBT = true
)
</code></pre>

<img src="https://user-images.githubusercontent.com/76413218/151527444-d0e03080-7b31-42f0-aa53-a14fcc15cd44.png" width="500" />
</details>

<details>
<summary>Modal theme white and CBT enabled</summary>

<pre><code>
afterpayBreakdown.moreInfoOptions = AfterpayMoreInfoOptions(
    modalTheme = AfterpayModalTheme.WHITE,
    isCBT = true
)
</code></pre>

<img src="https://user-images.githubusercontent.com/76413218/151527700-a9f3caab-7a45-4713-8321-a1b2b70b7e49.png" width="500" />
</details>

<details>
<summary>Modal ID set to 'en_US'</summary>

Setting a different locale with the modal ID should not be done in production, rather this is a demonstration that modal ID can be used.

<pre><code>
afterpayBreakdown.moreInfoOptions = AfterpayMoreInfoOptions(
    modalId = "en_US"
)
</code></pre>

<img src="https://user-images.githubusercontent.com/76413218/151527927-de3ef6e2-1637-495e-a3cc-8f3d59d1a042.png" width="500" />
</details>