### PR TITLE
EIT-1400: Hide decimals for limits on messaging

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInstalment.kt
@@ -78,9 +78,12 @@ internal sealed class AfterpayInstalment {
 
             val minimumAmount = configuration.minimumAmount ?: BigDecimal.ZERO
             if (totalCost < minimumAmount || totalCost > configuration.maximumAmount) {
+                val currencyFormatterNoDecimals = currencyFormatter.clone() as DecimalFormat
+                currencyFormatterNoDecimals.maximumFractionDigits = 0
+
                 return NotAvailable(
-                    minimumAmount = configuration.minimumAmount?.let(currencyFormatter::format),
-                    maximumAmount = currencyFormatter.format(configuration.maximumAmount)
+                    minimumAmount = configuration.minimumAmount?.let(currencyFormatterNoDecimals::format),
+                    maximumAmount = currencyFormatterNoDecimals.format(configuration.maximumAmount)
                 )
             }
 


### PR DESCRIPTION
## Summary of Changes

- Remove the decimal places for outside limit messaging to shorten and clean up the look of it

## Screenshots

| Previous | New |
|----------|-----|
|    <img width="331" alt="Screen Shot 2022-08-05 at 16 34 36" src="https://user-images.githubusercontent.com/76413218/183016697-4a67c71a-6b93-48f1-8843-804f84c34de7.png">       |      <img width="331" alt="Screen Shot 2022-08-05 at 16 35 59" src="https://user-images.githubusercontent.com/76413218/183016739-174a30a8-b66a-4865-b4d7-d74f1ea12335.png">      |

