### PR TITLE
fix: example app use correct state value for checkout mode

### DIFF
--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
@@ -137,7 +137,7 @@ class CheckoutViewModel(
     }
 
     fun loadCheckoutToken() {
-        val (email, total, isExpress) = state.value
+        val (email, total, _, isExpress) = state.value
         val symbols = DecimalFormatSymbols(Locale.US)
         val amount = DecimalFormat("0.00", symbols).format(total)
         val mode = if (isExpress) CheckoutMode.EXPRESS else CheckoutMode.STANDARD


### PR DESCRIPTION
## Summary of Changes

Ensure the correct property is pulled from state in `CheckoutViewModel` when determining checkout mode in the example app (express or standard). This defect was introduced when adding a preference for whether to use V1 or V2 as the order of values changed.