### PR TITLE
EIT-2096: add support for reverse integrations

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -11,6 +11,7 @@ import com.afterpay.android.internal.Locales
 import com.afterpay.android.internal.getCancellationStatusExtra
 import com.afterpay.android.internal.getOrderTokenExtra
 import com.afterpay.android.internal.getRegionLanguage
+import com.afterpay.android.internal.putCheckoutShouldLoadRedirectUrls
 import com.afterpay.android.internal.putCheckoutUrlExtra
 import com.afterpay.android.internal.putCheckoutV2OptionsExtra
 import com.afterpay.android.view.AfterpayCheckoutActivity
@@ -55,10 +56,11 @@ object Afterpay {
      * Afterpay checkout.
      */
     @JvmStatic
-    fun createCheckoutIntent(context: Context, checkoutUrl: String): Intent {
+    fun createCheckoutIntent(context: Context, checkoutUrl: String, loadRedirectUrls: Boolean = false): Intent {
         val url = if (enabled) { checkoutUrl } else { "LANGUAGE_NOT_SUPPORTED" }
         return Intent(context, AfterpayCheckoutActivity::class.java)
             .putCheckoutUrlExtra(url)
+            .putCheckoutShouldLoadRedirectUrls(loadRedirectUrls)
     }
 
     /**

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Intent.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Intent.kt
@@ -11,6 +11,7 @@ private object AfterpayIntent {
     const val INFO_URL = "AFTERPAY_INFO_URL"
     const val ORDER_TOKEN = "AFTERPAY_ORDER_TOKEN"
     const val CANCELLATION_STATUS = "AFTERPAY_CANCELLATION_STATUS"
+    const val SHOULD_LOAD_REDIRECT_URLS = "AFTERPAY_SHOULD_LOAD_REDIRECT_URLS"
 }
 
 internal fun Intent.putCheckoutUrlExtra(url: String): Intent =
@@ -18,6 +19,12 @@ internal fun Intent.putCheckoutUrlExtra(url: String): Intent =
 
 internal fun Intent.getCheckoutUrlExtra(): String? =
     getStringExtra(AfterpayIntent.CHECKOUT_URL)
+
+internal fun Intent.putCheckoutShouldLoadRedirectUrls(bool: Boolean): Intent =
+    putExtra(AfterpayIntent.SHOULD_LOAD_REDIRECT_URLS, bool)
+
+internal fun Intent.getCheckoutShouldLoadRedirectUrls(): Boolean =
+    getBooleanExtra(AfterpayIntent.SHOULD_LOAD_REDIRECT_URLS, false)
 
 internal fun Intent.putCheckoutV2OptionsExtra(options: AfterpayCheckoutV2Options): Intent =
     putExtra(AfterpayIntent.CHECKOUT_OPTIONS, options)

--- a/docs/getting-started/checkout-v1.md
+++ b/docs/getting-started/checkout-v1.md
@@ -28,6 +28,13 @@ class ExampleActivity: Activity {
         val afterpayCheckoutButton = findViewById<Button>(R.id.button_afterpay)
         afterpayCheckoutButton.setOnClickListener {
             val checkoutUrl = api.checkoutWithAfterpay(cart)
+            /**
+             * the `createCheckoutIntent` method takes an optional 3rd paramater: `loadRedirectUrls`
+             * of type boolean. Setting this to true will allow the redirect urls that were set when
+             * creating the checkout to be loaded.
+             *
+             * The default & recommended value is false unless under specific circumstances this is required.
+             */
             val intent = Afterpay.createCheckoutIntent(this, checkoutUrl)
             startActivityForResult(intent, CHECKOUT_WITH_AFTERPAY)
         }

--- a/docs/getting-started/checkout-v1.md
+++ b/docs/getting-started/checkout-v1.md
@@ -29,7 +29,7 @@ class ExampleActivity: Activity {
         afterpayCheckoutButton.setOnClickListener {
             val checkoutUrl = api.checkoutWithAfterpay(cart)
             /**
-             * the `createCheckoutIntent` method takes an optional 3rd paramater: `loadRedirectUrls`
+             * The `createCheckoutIntent` method takes an optional 3rd parameter: `loadRedirectUrls`
              * of type boolean. Setting this to true will allow the redirect urls that were set when
              * creating the checkout to be loaded.
              *


### PR DESCRIPTION
## Summary of Changes

- Allow redirect urls to be loaded for V1 if the checkout intent is created (`Afterpay.createCheckoutIntent()`) with the 3rd parameter (`loadRedirectUrls`) set to `true`

## Submission Checklist

- [x] Documentation is changed or added.
