### PR TITLE
Adding Dev Options menu for easier dev and QA

### DIFF
--- a/example/build.gradle
+++ b/example/build.gradle
@@ -44,6 +44,10 @@ android {
         jvmTarget = versions.java
     }
 
+    buildFeatures {
+        viewBinding true
+    }
+
     testOptions {
         execution 'ANDROIDX_TEST_ORCHESTRATOR'
     }

--- a/example/src/main/kotlin/com/example/afterpay/Dependencies.kt
+++ b/example/src/main/kotlin/com/example/afterpay/Dependencies.kt
@@ -4,6 +4,8 @@ import android.app.Application
 import android.content.Context
 import android.content.SharedPreferences
 import com.example.afterpay.data.MerchantApi
+import com.example.afterpay.util.getHostname
+import com.example.afterpay.util.getPort
 import com.squareup.moshi.Moshi
 import com.squareup.moshi.kotlin.reflect.KotlinJsonAdapterFactory
 import retrofit2.Retrofit
@@ -16,9 +18,21 @@ private var dependencies: Dependencies? = null
 fun initializeDependencies(application: Application) = check(dependencies == null) {
     "Dependencies should only be initialized once"
 }.also {
+    // Create SharedPreferences object.
+    val preferences = application.getSharedPreferences(
+        application.getString(R.string.preferences),
+        Context.MODE_PRIVATE,
+    )
+
+    // Get hostname from SharedPreferences.
+    var hostname = preferences.getHostname()
+    val port = preferences.getPort()
+    if (port.isNotBlank()) {
+        hostname = "$hostname:$port"
+    }
     dependencies = Dependencies(
         merchantApi = Retrofit.Builder()
-            .baseUrl("https://10.0.2.2:3001")
+            .baseUrl(hostname)
             .addConverterFactory(
                 MoshiConverterFactory.create(
                     Moshi.Builder()
@@ -28,10 +42,7 @@ fun initializeDependencies(application: Application) = check(dependencies == nul
             )
             .build()
             .create(MerchantApi::class.java),
-        sharedPreferences = application.getSharedPreferences(
-            application.getString(R.string.preferences),
-            Context.MODE_PRIVATE,
-        ),
+        sharedPreferences = preferences,
     )
 }
 

--- a/example/src/main/kotlin/com/example/afterpay/MainViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/MainViewModel.kt
@@ -1,0 +1,84 @@
+package com.example.afterpay
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import app.cash.paykit.core.CashAppPayKit
+import app.cash.paykit.core.CashAppPayKitFactory
+import app.cash.paykit.core.CashAppPayKitListener
+import app.cash.paykit.core.PayKitState
+import com.afterpay.android.Afterpay
+import com.afterpay.android.AfterpayEnvironment
+import com.example.afterpay.data.AfterpayRepository
+import com.example.afterpay.util.Logger
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import java.util.Locale
+
+class MainViewModel : ViewModel(), CashAppPayKitListener {
+
+    private val _payKitState = MutableStateFlow<PayKitState>(PayKitState.NotStarted)
+    val payKitState: StateFlow<PayKitState> = _payKitState.asStateFlow()
+
+    var environment: AfterpayEnvironment = AfterpayEnvironment.SANDBOX
+        private set
+
+    private val afterpayRepository by lazy {
+        AfterpayRepository(
+            merchantApi = getDependencies().merchantApi,
+            preferences = getDependencies().sharedPreferences,
+        )
+    }
+
+    var payKit: CashAppPayKit? = null
+
+    suspend fun applyAfterpayConfiguration(forceRefresh: Boolean = false) {
+        try {
+            val configuration = withContext(Dispatchers.IO) {
+                afterpayRepository.fetchConfiguration(forceRefresh)
+            }
+
+            Afterpay.setConfiguration(
+                minimumAmount = configuration.minimumAmount,
+                maximumAmount = configuration.maximumAmount,
+                currencyCode = configuration.currency,
+                locale = Locale(configuration.language, configuration.country),
+                environment = environment,
+            )
+
+            setupPayKit()
+        } catch (e: Exception) {
+            Logger().error(message = "Failed to get afterpay configuration.", tr = e)
+        }
+    }
+
+    fun setEnvironment(environment: AfterpayEnvironment) {
+        this.environment = environment
+        viewModelScope.launch {
+            applyAfterpayConfiguration(true)
+        }
+    }
+
+    override fun payKitStateDidChange(newState: PayKitState) {
+        _payKitState.value = newState
+        MainCommands.commandChannel.trySend(MainCommands.Command.PayKitStateChange(newState))
+    }
+
+    private fun setupPayKit() {
+        Afterpay.environment?.let { env ->
+            if (payKit != null) {
+                payKit?.unregisterFromStateUpdates()
+            }
+
+            payKit = when (env) {
+                AfterpayEnvironment.PRODUCTION -> CashAppPayKitFactory.create(env.payKitId)
+                else -> CashAppPayKitFactory.createSandbox(env.payKitId)
+            }
+
+            payKit?.registerForStateUpdates(this)
+        }
+    }
+}

--- a/example/src/main/kotlin/com/example/afterpay/checkout/BottomSheetOptionsFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/BottomSheetOptionsFragment.kt
@@ -1,0 +1,83 @@
+package com.example.afterpay.checkout
+
+import android.os.Bundle
+import android.view.LayoutInflater
+import android.view.View
+import android.view.ViewGroup
+import android.widget.Toast
+import androidx.core.content.edit
+import androidx.fragment.app.activityViewModels
+import androidx.lifecycle.lifecycleScope
+import com.afterpay.android.AfterpayEnvironment
+import com.example.afterpay.MainViewModel
+import com.example.afterpay.R
+import com.example.afterpay.databinding.FragmentBottomSheetBinding
+import com.example.afterpay.getDependencies
+import com.example.afterpay.util.getHostname
+import com.example.afterpay.util.getPort
+import com.example.afterpay.util.putHostname
+import com.example.afterpay.util.putPort
+import com.google.android.material.bottomsheet.BottomSheetDialogFragment
+import kotlinx.coroutines.launch
+
+class BottomSheetOptionsFragment : BottomSheetDialogFragment() {
+
+    private var _binding: FragmentBottomSheetBinding? = null
+
+    private val activityViewModel: MainViewModel by activityViewModels()
+
+    private val binding get() = _binding!!
+
+    override fun onCreateView(
+        inflater: LayoutInflater,
+        container: ViewGroup?,
+        savedInstanceState: Bundle?,
+    ): View {
+        _binding = FragmentBottomSheetBinding.inflate(inflater, container, false)
+        return binding.root
+    }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        binding.refreshConfigurationButton.setOnClickListener {
+            lifecycleScope.launch {
+                activityViewModel.applyAfterpayConfiguration(forceRefresh = true)
+            }
+        }
+
+        val preferences = getDependencies().sharedPreferences
+
+        // Populate fields.
+        binding.hostField.setText(preferences.getHostname())
+        binding.portField.setText(preferences.getPort())
+        if (activityViewModel.environment == AfterpayEnvironment.PRODUCTION) {
+            binding.environmentToggleButton.check(R.id.productionButton)
+        } else {
+            binding.environmentToggleButton.check(R.id.sandboxButton)
+        }
+
+        // Environment Toggle Buttons.
+        binding.sandboxButton.setOnClickListener {
+            activityViewModel.setEnvironment(AfterpayEnvironment.SANDBOX)
+        }
+        binding.productionButton.setOnClickListener {
+            activityViewModel.setEnvironment(AfterpayEnvironment.PRODUCTION)
+        }
+
+        binding.applyChangesButton.setOnClickListener {
+            preferences.edit {
+                putHostname(binding.hostField.text.toString())
+                putPort(binding.portField.text.toString())
+            }
+            Toast.makeText(
+                requireContext(),
+                R.string.dev_options_restart_app,
+                Toast.LENGTH_LONG,
+            ).show()
+        }
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
+    }
+}

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -12,18 +12,18 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.core.os.bundleOf
 import androidx.core.widget.addTextChangedListener
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.activityViewModels
 import androidx.fragment.app.viewModels
 import androidx.lifecycle.lifecycleScope
 import androidx.navigation.fragment.findNavController
-import app.cash.paykit.core.CashAppPayKit
 import app.cash.paykit.core.PayKitState
 import app.cash.paykit.core.ui.CashPayKitButton
 import com.afterpay.android.Afterpay
 import com.afterpay.android.cashapp.CashAppSignOrderResult
 import com.afterpay.android.cashapp.CashAppValidationResponse
 import com.afterpay.android.view.AfterpayPaymentButton
-import com.example.afterpay.MainActivity
 import com.example.afterpay.MainCommands
+import com.example.afterpay.MainViewModel
 import com.example.afterpay.NavGraph
 import com.example.afterpay.R
 import com.example.afterpay.checkout.CheckoutViewModel.Command
@@ -38,7 +38,9 @@ import kotlinx.coroutines.launch
 import java.math.BigDecimal
 
 class CheckoutFragment : Fragment() {
-    val logger = LoggerFactory.getLogger()
+    private val logger = LoggerFactory.getLogger()
+
+    private val activityViewModel: MainViewModel by activityViewModels()
 
     private companion object {
         const val CHECKOUT_WITH_AFTERPAY = 1234
@@ -55,15 +57,6 @@ class CheckoutFragment : Fragment() {
     }
 
     private lateinit var cashButton: CashPayKitButton
-
-    private val payKitInstance: CashAppPayKit?
-        get() {
-            if (activity is MainActivity) {
-                return (activity as MainActivity).payKit
-            }
-
-            return null
-        }
 
     private var cashJwt: String? = null
 
@@ -84,7 +77,7 @@ class CheckoutFragment : Fragment() {
                 is CashAppSignOrderResult.Success -> {
                     val (response) = createOrderResult
                     cashJwt = response.jwt
-                    viewModel.createCustomerRequest(response, payKitInstance)
+                    viewModel.createCustomerRequest(response, activityViewModel.payKit)
                 }
                 is CashAppSignOrderResult.Failure -> {
                     val (error) = createOrderResult
@@ -196,7 +189,7 @@ class CheckoutFragment : Fragment() {
                             }
                     }
                     is Command.LaunchCashAppPay -> {
-                        viewModel.authorizePayKitCustomerRequest(requireContext(), payKitInstance)
+                        viewModel.authorizePayKitCustomerRequest(requireContext(), activityViewModel.payKit)
                     }
                     is Command.CashReceipt -> {
                         cashJwt?.also { jwt ->

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutViewModel.kt
@@ -28,6 +28,18 @@ import com.example.afterpay.data.CheckoutRequest
 import com.example.afterpay.data.MerchantApi
 import com.example.afterpay.getDependencies
 import com.example.afterpay.util.asCurrency
+import com.example.afterpay.util.getBuyNow
+import com.example.afterpay.util.getEmail
+import com.example.afterpay.util.getExpress
+import com.example.afterpay.util.getPickup
+import com.example.afterpay.util.getShippingOptionsRequired
+import com.example.afterpay.util.getVersion
+import com.example.afterpay.util.putBuyNow
+import com.example.afterpay.util.putEmail
+import com.example.afterpay.util.putExpress
+import com.example.afterpay.util.putPickup
+import com.example.afterpay.util.putShippingOptionsRequired
+import com.example.afterpay.util.putVersion
 import com.example.afterpay.util.update
 import com.example.afterpay.util.viewModelFactory
 import kotlinx.coroutines.Dispatchers
@@ -293,37 +305,3 @@ class CheckoutViewModel(
         }
     }
 }
-
-private object PreferenceKey {
-    const val email = "email"
-    const val useV1 = "useV1"
-    const val express = "express"
-    const val buyNow = "buyNow"
-    const val pickup = "pickup"
-    const val shippingOptionsRequired = "shippingOptionsRequired"
-}
-
-private fun SharedPreferences.getEmail(): String = getString(PreferenceKey.email, null) ?: ""
-private fun SharedPreferences.Editor.putEmail(email: String) = putString(PreferenceKey.email, email)
-
-private fun SharedPreferences.getExpress(): Boolean = getBoolean(PreferenceKey.express, false)
-private fun SharedPreferences.Editor.putExpress(isExpress: Boolean) =
-    putBoolean(PreferenceKey.express, isExpress)
-
-private fun SharedPreferences.getVersion(): Boolean = getBoolean(PreferenceKey.useV1, false)
-private fun SharedPreferences.Editor.putVersion(useV1: Boolean) =
-    putBoolean(PreferenceKey.useV1, useV1)
-
-private fun SharedPreferences.getBuyNow(): Boolean = getBoolean(PreferenceKey.buyNow, false)
-private fun SharedPreferences.Editor.putBuyNow(isBuyNow: Boolean) =
-    putBoolean(PreferenceKey.buyNow, isBuyNow)
-
-private fun SharedPreferences.getPickup(): Boolean = getBoolean(PreferenceKey.pickup, false)
-private fun SharedPreferences.Editor.putPickup(isPickup: Boolean) =
-    putBoolean(PreferenceKey.pickup, isPickup)
-
-private fun SharedPreferences.getShippingOptionsRequired(): Boolean =
-    getBoolean(PreferenceKey.shippingOptionsRequired, false)
-
-private fun SharedPreferences.Editor.putShippingOptionsRequired(isShippingOptionsRequired: Boolean) =
-    putBoolean(PreferenceKey.shippingOptionsRequired, isShippingOptionsRequired)

--- a/example/src/main/kotlin/com/example/afterpay/util/SharedPreferencesExtensions.kt
+++ b/example/src/main/kotlin/com/example/afterpay/util/SharedPreferencesExtensions.kt
@@ -1,0 +1,45 @@
+package com.example.afterpay.util
+
+import android.content.SharedPreferences
+
+private object PreferenceKey {
+    const val email = "email"
+    const val useV1 = "useV1"
+    const val express = "express"
+    const val buyNow = "buyNow"
+    const val pickup = "pickup"
+    const val shippingOptionsRequired = "shippingOptionsRequired"
+    const val hostname = "hostname"
+    const val port = "port"
+}
+
+fun SharedPreferences.getEmail(): String = getString(PreferenceKey.email, null) ?: ""
+fun SharedPreferences.Editor.putEmail(email: String) = putString(PreferenceKey.email, email)
+
+fun SharedPreferences.getExpress(): Boolean = getBoolean(PreferenceKey.express, false)
+fun SharedPreferences.Editor.putExpress(isExpress: Boolean) =
+    putBoolean(PreferenceKey.express, isExpress)
+
+fun SharedPreferences.getVersion(): Boolean = getBoolean(PreferenceKey.useV1, false)
+fun SharedPreferences.Editor.putVersion(useV1: Boolean) =
+    putBoolean(PreferenceKey.useV1, useV1)
+
+fun SharedPreferences.getBuyNow(): Boolean = getBoolean(PreferenceKey.buyNow, false)
+fun SharedPreferences.Editor.putBuyNow(isBuyNow: Boolean) =
+    putBoolean(PreferenceKey.buyNow, isBuyNow)
+
+fun SharedPreferences.getPickup(): Boolean = getBoolean(PreferenceKey.pickup, false)
+fun SharedPreferences.Editor.putPickup(isPickup: Boolean) =
+    putBoolean(PreferenceKey.pickup, isPickup)
+
+fun SharedPreferences.getShippingOptionsRequired(): Boolean =
+    getBoolean(PreferenceKey.shippingOptionsRequired, false)
+
+fun SharedPreferences.Editor.putShippingOptionsRequired(isShippingOptionsRequired: Boolean) =
+    putBoolean(PreferenceKey.shippingOptionsRequired, isShippingOptionsRequired)
+
+fun SharedPreferences.getHostname(): String = getString(PreferenceKey.hostname, "https://10.0.2.2") ?: "https://10.0.2.2"
+fun SharedPreferences.Editor.putHostname(hostname: String) = putString(PreferenceKey.hostname, hostname)
+
+fun SharedPreferences.getPort(): String = getString(PreferenceKey.port, "3001") ?: ""
+fun SharedPreferences.Editor.putPort(port: String) = putString(PreferenceKey.port, port)

--- a/example/src/main/res/drawable/ic_logo_dev.xml
+++ b/example/src/main/res/drawable/ic_logo_dev.xml
@@ -1,0 +1,6 @@
+<vector android:height="24dp" android:tint="@color/light_grey"
+    android:viewportHeight="24" android:viewportWidth="24"
+    android:width="24dp" xmlns:android="http://schemas.android.com/apk/res/android">
+    <path android:fillColor="@color/light_grey" android:strokeColor="@color/light_grey" android:pathData="M19,3H5C3.9,3 3,3.9 3,5v14c0,1.1 0.9,2 2,2h14c1.1,0 2,-0.9 2,-2V5C21,3.9 20.1,3 19,3zM7.68,14.98H6V9h1.71c1.28,0 1.71,1.03 1.71,1.71l0,2.56C9.42,13.95 9,14.98 7.68,14.98zM12.38,11.46v1.07h-1.18v1.39h1.93v1.07h-2.25c-0.4,0.01 -0.74,-0.31 -0.75,-0.71V9.75c-0.01,-0.4 0.31,-0.74 0.71,-0.75h2.28l0,1.07h-1.92v1.39H12.38zM16.88,14.23c-0.48,1.11 -1.33,0.89 -1.71,0L13.77,9h1.18l1.07,4.11L17.09,9h1.18L16.88,14.23z"/>
+    <path android:strokeColor="@color/light_grey" android:fillColor="@color/light_grey" android:pathData="M7.77,10.12H7.14v3.77h0.63c0.14,0 0.28,-0.05 0.42,-0.16c0.14,-0.1 0.21,-0.26 0.21,-0.47v-2.52c0,-0.21 -0.07,-0.37 -0.21,-0.47C8.05,10.17 7.91,10.12 7.77,10.12z"/>
+</vector>

--- a/example/src/main/res/layout/fragment_bottom_sheet.xml
+++ b/example/src/main/res/layout/fragment_bottom_sheet.xml
@@ -1,0 +1,134 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:orientation="vertical"
+    android:id="@+id/sheetRoot"
+    android:padding="8dp"
+    >
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="@string/dev_options_title"
+        android:textAppearance="?attr/textAppearanceHeadline4" />
+
+    <com.google.android.material.button.MaterialButtonToggleGroup
+        android:id="@+id/environmentToggleButton"
+        android:layout_width="match_parent"
+        android:layout_marginTop="16dp"
+        android:layout_height="wrap_content"
+        app:singleSelection="true"
+        app:selectionRequired="true"
+        app:checkedButton="@+id/productionButton"
+        >
+        <Button
+            style="?attr/materialButtonOutlinedStyle"
+            android:id="@+id/productionButton"
+            android:layout_weight="1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dev_options_env_production"
+            />
+        <Button
+            style="?attr/materialButtonOutlinedStyle"
+            android:id="@+id/sandboxButton"
+            android:layout_weight="1"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/dev_options_env_sandbox"
+            />
+
+    </com.google.android.material.button.MaterialButtonToggleGroup>
+
+
+    <!-- Base URL -->
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="8dp"
+        android:alpha="0.4"
+        android:background="@color/separator_color"
+        />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/dev_options_host_title"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        />
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/hostContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="16dp"
+        android:hint="@string/dev_options_host_hint"
+        >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/hostField"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="text"
+            />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+
+    <com.google.android.material.textfield.TextInputLayout
+        android:id="@+id/portContainer"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:hint="@string/dev_options_port_hint"
+        >
+
+        <com.google.android.material.textfield.TextInputEditText
+            android:id="@+id/portField"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:inputType="number"
+            />
+
+    </com.google.android.material.textfield.TextInputLayout>
+
+    <Button
+        android:id="@+id/applyChangesButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginVertical="16dp"
+        android:drawableStart="@drawable/ic_refresh_24"
+        android:text="@string/dev_options_apply_changes" />
+
+    <!-- AfterPay Refresh -->
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="8dp"
+        android:alpha="0.4"
+        android:background="@color/separator_color"
+        />
+
+    <TextView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="8dp"
+        android:text="@string/dev_options_afterpay_title"
+        android:textAppearance="?attr/textAppearanceSubtitle1"
+        />
+
+    <Button
+        android:id="@+id/refreshConfigurationButton"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center_horizontal"
+        android:layout_marginVertical="24dp"
+        android:drawableStart="@drawable/ic_refresh_24"
+        android:text="@string/refresh_configuration" />
+
+</LinearLayout>

--- a/example/src/main/res/menu/menu.xml
+++ b/example/src/main/res/menu/menu.xml
@@ -3,8 +3,8 @@
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <item
-        android:id="@+id/action_refresh_config"
-        android:icon="@drawable/ic_refresh_24"
-        android:title="@string/refresh_configuration"
+        android:id="@+id/devButton"
+        android:icon="@drawable/ic_logo_dev"
+        android:title="@string/dev_options_title"
         app:showAsAction="always" />
 </menu>

--- a/example/src/main/res/values/colors.xml
+++ b/example/src/main/res/values/colors.xml
@@ -8,4 +8,5 @@
     <color name="afterpay_navy_dark">#001F4C</color>
 
     <color name="light_grey">#D6D6D9</color>
+    <color name="separator_color">#111111</color>
 </resources>

--- a/example/src/main/res/values/strings.xml
+++ b/example/src/main/res/values/strings.xml
@@ -26,4 +26,15 @@
     <string name="cash_tag">Cash Tag: %1$s</string>
     <string name="cash_amount">Cash Amount: $%1$s</string>
     <string name="cash_grant_id">Cash Grant Id: %1$s</string>
+
+    <!-- Dev Options -->
+    <string name="dev_options_title">Dev Options</string>
+    <string name="dev_options_env_production">Production</string>
+    <string name="dev_options_env_sandbox">Sandbox</string>
+    <string name="dev_options_host_title">Base URL</string>
+    <string name="dev_options_afterpay_title">AfterPay Configuration</string>
+    <string name="dev_options_host_hint">Host</string>
+    <string name="dev_options_port_hint">Port</string>
+    <string name="dev_options_apply_changes">Apply Changes</string>
+    <string name="dev_options_restart_app">Restart app to enforce new config!</string>
 </resources>


### PR DESCRIPTION
## Summary of Changes

Adding Dev menu to example app, to provide easier testing and development.

 - Created a `BottomSheetOptionsFragment`, that allows users to set the `host` and `port` of the remote server, and well as alternate between `prod` and `sandbox` environments easily. 
 - To achieve this, I moved `PayKit` into a shared view model that lives at the Activity levels, by the name of `MainViewModel`, so that Cash App Pay SDK wouldn't be attached to a specific fragment or activity.

## Verification

In the video below, I'm changing the host against a server I'm running on my machine, and connecting to it with my phone which is connected via data and not WiFi. Changing hosts requires an app restart, but changing between prod and sandbox does NOT - the app will give instructions to restart when applicable.


https://user-images.githubusercontent.com/416941/221694773-bed5b2f0-b5e0-4f23-8b17-de47fde3478a.mp4

