### PR TITLE
EIT-2362 - Feature: manually set consumer locale

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/Afterpay.kt
@@ -44,7 +44,7 @@ object Afterpay {
         get() = Brand.forLocale(locale)
 
     internal val language: Locale?
-        get() = getRegionLanguage(locale, Locale.getDefault())
+        get() = getRegionLanguage(locale, configuration?.consumerLocale ?: Locale.getDefault())
 
     internal val enabled: Boolean
         get() = language != null
@@ -187,6 +187,7 @@ object Afterpay {
         currencyCode: String,
         locale: Locale,
         environment: AfterpayEnvironment,
+        consumerLocale: Locale? = null,
     ) {
         configuration = Configuration(
             minimumAmount = minimumAmount?.toBigDecimal(),
@@ -194,6 +195,7 @@ object Afterpay {
             currency = Currency.getInstance(currencyCode),
             locale = locale.clone() as Locale,
             environment = environment,
+            consumerLocale = consumerLocale,
         ).also { configuration ->
             if (configuration.maximumAmount < BigDecimal.ZERO) {
                 throw IllegalArgumentException("Maximum order amount is invalid")

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Configuration.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Configuration.kt
@@ -11,4 +11,5 @@ internal data class Configuration(
     val currency: Currency,
     val locale: Locale,
     val environment: AfterpayEnvironment,
+    val consumerLocale: Locale?,
 )

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Configuration.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Configuration.kt
@@ -11,5 +11,5 @@ internal data class Configuration(
     val currency: Currency,
     val locale: Locale,
     val environment: AfterpayEnvironment,
-    val consumerLocale: Locale?,
+    val consumerLocale: Locale? = null,
 )

--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/Locales.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/Locales.kt
@@ -37,8 +37,8 @@ internal object Locales {
     )
 }
 
-internal fun getRegionLanguage(merchantLocale: Locale, clientLocale: Locale): Locale? {
+internal fun getRegionLanguage(merchantLocale: Locale, consumerLocale: Locale): Locale? {
     return validRegionLanguages[merchantLocale.country]?.find {
-        clientLocale.language == it.language
+        consumerLocale.language == it.language
     }
 }

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayEnabled.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayEnabled.kt
@@ -15,7 +15,7 @@ class AfterpayEnabled {
             currencyCode = "AUD",
             locale = Locale.US,
             environment = environment,
-            consumerLocale = Locale.ENGLISH
+            consumerLocale = Locale.ENGLISH,
         )
 
         Assert.assertEquals(true, Afterpay.enabled)
@@ -29,7 +29,7 @@ class AfterpayEnabled {
             currencyCode = "AUD",
             locale = Locale.US,
             environment = environment,
-            consumerLocale = Locale.FRANCE
+            consumerLocale = Locale.FRANCE,
         )
 
         Assert.assertEquals(false, Afterpay.enabled)

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayEnabled.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayEnabled.kt
@@ -1,0 +1,37 @@
+package com.afterpay.android
+
+import org.junit.Assert
+import org.junit.Test
+import java.util.Locale
+
+class AfterpayEnabled {
+    private val environment = AfterpayEnvironment.SANDBOX
+
+    @Test
+    fun `Afterpay is enabled for basic config and locale is English`() {
+        Afterpay.setConfiguration(
+            minimumAmount = "10.00",
+            maximumAmount = "100.00",
+            currencyCode = "AUD",
+            locale = Locale.US,
+            environment = environment,
+            consumerLocale = Locale.ENGLISH
+        )
+
+        Assert.assertEquals(true, Afterpay.enabled)
+    }
+
+    @Test
+    fun `Afterpay is not enabled for basic config and language is not available for merchant country`() {
+        Afterpay.setConfiguration(
+            minimumAmount = "10.00",
+            maximumAmount = "100.00",
+            currencyCode = "AUD",
+            locale = Locale.US,
+            environment = environment,
+            consumerLocale = Locale.FRANCE
+        )
+
+        Assert.assertEquals(false, Afterpay.enabled)
+    }
+}


### PR DESCRIPTION
## Summary of Changes

This PR aims to allow for the consumer locale to be set in `Afterpay.setConfiguration()`. A breaking change was made in [v4.0.0](https://github.com/afterpay/sdk-android/releases/tag/v4.0.0) where a consumer's locale language must match the available languages for the merchant's locale. The consumer's locale was taken from the OS. This PR aims to allow the consumer's locale to be set for applications where a locale picker is available.

- use locale from config to get internal language, with default to OS
- a new optional parameter for `Configuration` class and `setConfiguration` method
- tests for locale options where the internal `Afterpay.enabled` is `true` / `false`

## Submission Checklist

- [x] Tests are included.
