### PR TITLE
EIT-2910 - Fix: Cash App validation network on main thread

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/cashapp/AfterpayCashAppCheckout.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/cashapp/AfterpayCashAppCheckout.kt
@@ -77,7 +77,7 @@ object AfterpayCashAppCheckout {
 
                 val payload = Json.encodeToString(request)
 
-                val response = withContext(Dispatchers.Unconfined) {
+                val response = withContext(Dispatchers.IO) {
                     AfterpayCashAppApi.cashRequest<AfterpayCashAppValidationResponse, String>(
                         url = url,
                         method = AfterpayCashAppApi.CashHttpVerb.POST,

--- a/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
+++ b/example/src/main/kotlin/com/example/afterpay/checkout/CheckoutFragment.kt
@@ -279,7 +279,7 @@ class CheckoutFragment : Fragment() {
 
     private fun loadCashCheckoutToken() {
         if (!launchedCashApp) {
-            lifecycleScope.launch(Dispatchers.Unconfined) {
+            lifecycleScope.launch(Dispatchers.IO) {
                 viewModel.loadCheckoutToken(true)
             }
         }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Change `Dispatchers.Unconfined` to `Dispatchers.IO` to prevent network calls running on the main thread

