### PR TITLE
EIT-2915 - update scss in docs for Just The Docs changes

### DIFF
--- a/docs/_sass/color_schemes/afterpay.scss
+++ b/docs/_sass/color_schemes/afterpay.scss
@@ -3,5 +3,5 @@
 $link-color: #3d75ca;
 $feedback-color: rgb(223, 234, 246);
 $sidebar-color: $white;
-$nav-width: 300px;
-$nav-width-md: 300px;
+$nav-width: 18.75rem;
+$nav-width-md: 18.75rem;


### PR DESCRIPTION
## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Change pixel value in `scss` for documentation due to updates to Just the Docs package

## Notes
- Just the Docs updated to use `rem` values instead of `px`. This caused errors when setting a variable that would attempt to add the `px` value to the `rem`.