### PR TITLE
CAP PayKit release 2.3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,6 +84,7 @@ obj/
 .idea/runConfigurations.xml
 .idea/deploymentTargetDropDown.xml
 .idea/kotlinc.xml
+.idea/appInsightsSettings.xml
 
 # OS-specific files
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -31,7 +31,7 @@ buildscript {
         'espresso'                  : '3.5.1',
         'uiautomator'               : '2.2.0',
         'ktlint'                    : '0.49.1',
-        'cash_app_paykit_sdk'       : '2.2.1',
+        'cash_app_paykit_sdk'       : '2.3.0',
         'mockk'                     : '1.13.5'
     ]
 

--- a/docs/getting-started/cash-app-pay.md
+++ b/docs/getting-started/cash-app-pay.md
@@ -208,9 +208,9 @@ The `Approved` state will contain a **Grants list** object associated with it an
 
 [cash-on-maven]: https://central.sonatype.com/artifact/app.cash.paykit/core/1.0.3/overview
 [configure-afterpay]: ../configuring-the-sdk
-[sandbox-app]: https://cashapp-pay.stoplight.io/docs/api/technical-documentation/sandbox/sandbox-app
+[sandbox-app]: https://developers.cash.app/docs/api/technical-documentation/sandbox/sandbox-app
 [intent-filter]: https://developer.android.com/training/app-links/deep-linking#adding-filters
 [example-server-props]: https://github.com/afterpay/sdk-example-server/blob/5781eadb25d7f5c5d872e754fdbb7214a8068008/src/routes/checkout.ts#L26-L27
 [api-reference-props]: https://developers.afterpay.com/afterpay-online/reference/javascript-afterpayjs#redirect-method
-[cash-button-docs]: https://cashapp-pay.stoplight.io/docs/api/technical-documentation/sdks/pay-kit/android-getting-started#cashapppaybutton
+[cash-button-docs]: https://developers.cash.app/docs/api/technical-documentation/sdks/pay-kit/android-getting-started#cashapppaybutton
 [create-checkout-endpoint-docs]: https://developers.afterpay.com/afterpay-online/reference/create-checkout-1

--- a/docs/getting-started/cash-app-pay.md
+++ b/docs/getting-started/cash-app-pay.md
@@ -34,13 +34,13 @@ With our latest enhancements, you can now support taking Cash App Pay payments u
 You can get the the latest version of the SDK from Maven. This is the import definition using Gradle:
 
 ```gradle
-implementation "app.cash.paykit:core:2.0.0"
+implementation "app.cash.paykit:core:2.3.0"
 ```
 
 For definitions of other build systems, see [Cash App Pay Kit on Maven Central][cash-on-maven]{:target="_blank"}.
 
 {: .info }
-> Version `v2.0.0` of the SDK size is `12.3 kB`.
+> Version `v2.3.0` of the SDK size is `12.3 kB`.
 
 ## Step 2: Create a Cash App Pay Kit SDK Instance
 
@@ -212,5 +212,5 @@ The `Approved` state will contain a **Grants list** object associated with it an
 [intent-filter]: https://developer.android.com/training/app-links/deep-linking#adding-filters
 [example-server-props]: https://github.com/afterpay/sdk-example-server/blob/5781eadb25d7f5c5d872e754fdbb7214a8068008/src/routes/checkout.ts#L26-L27
 [api-reference-props]: https://developers.afterpay.com/afterpay-online/reference/javascript-afterpayjs#redirect-method
-[cash-button-docs]: https://cashapp-pay.stoplight.io/docs/api/technical-documentation/sdks/pay-kit/android-getting-started#cashpaykitbutton
+[cash-button-docs]: https://cashapp-pay.stoplight.io/docs/api/technical-documentation/sdks/pay-kit/android-getting-started#cashapppaybutton
 [create-checkout-endpoint-docs]: https://developers.afterpay.com/afterpay-online/reference/create-checkout-1

--- a/example/src/main/res/layout/fragment_checkout.xml
+++ b/example/src/main/res/layout/fragment_checkout.xml
@@ -199,7 +199,8 @@
 
     </ScrollView>
 
-    <app.cash.paykit.core.ui.CashAppPayLightButton
+    <app.cash.paykit.core.ui.CashAppPayButton
+        style="@style/CAPButtonStyle.Light"
         android:id="@+id/cart_button_cash"
         android:layout_height="54dp"
         android:layout_marginHorizontal="24dp"


### PR DESCRIPTION
Updating the internal version of CAP PayKit to match the latest release. 

Release notes: https://github.com/cashapp/cash-app-pay-android-sdk/releases/tag/v2.3.0