### PR TITLE
Refactor V3 + CAP

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/CheckoutV3.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/CheckoutV3.kt
@@ -160,6 +160,25 @@ internal object CheckoutV3 {
     }
 
     object Confirmation {
+        @Serializable
+        data class CashAppPayRequest(
+            val token: String,
+            val singleUseCardToken: String,
+            val cashAppPspInfo: CashAppPspInfo,
+        ) {
+            @Serializable
+            data class CashAppPspInfo(
+                val externalCustomerId: String,
+                val externalGrantId: String,
+                val jwt: String,
+            )
+        }
+
+        @Serializable
+        data class CashAppPayResponse(
+            val paymentDetails: PaymentDetails,
+            val cardValidUntil: String?,
+        )
 
         @Serializable
         data class Response(

--- a/afterpay/src/main/kotlin/com/afterpay/android/model/CheckoutV3CashAppPay.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/model/CheckoutV3CashAppPay.kt
@@ -1,0 +1,12 @@
+// Copyright Block, Inc.
+package com.afterpay.android.model
+
+data class CheckoutV3CashAppPay(
+    val token: String,
+    val singleUseCardToken: String,
+    val amount: Double,
+    val redirectUri: String,
+    val merchantId: String,
+    val brandId: String,
+    val jwt: String,
+)


### PR DESCRIPTION
I misunderstood where `isCashAppPay` is needed. It is not something that needs to be exposed and set by the merchant. It is internal to the SDK.

V3 + CAP doesn't launch any Afterpay Intent / UI. We need to expose the two network requests normally done in the Afterpay UI (see `CheckoutV3ViewModel`) directly to the merchant:

* perform checkout request
* perform confirmation request

Furthermore we can save the merchant some trouble by combining the perform checkout request with the sign token request

So we add two new functions to the API:

* `beginCheckoutV3WithCashAppPay`
* `confirmCheckoutV3WithCashAppPay`

In the process of this work I create an overload of `AfterpayCashAppCheckout.performSignPaymentRequest` which removes the unnecessary suspend + callback.

Grab the next PR if you want to see this in action: #224