### PR TITLE
Add missing build tools to sample app

### DIFF
--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -23,6 +23,7 @@ android {
     namespace = "com.example"
 
     compileSdk = libs.versions.exampleCompileSdk.get().toInt()
+    buildToolsVersion = libs.versions.buildTools.get()
 
     buildFeatures {
         viewBinding = true


### PR DESCRIPTION
Since we are still using an older version of AGP, we still need to define build tools version. 

See that sample app still builds.

I believe this is what's causing sample build error on Actions:

https://github.com/afterpay/sdk-android/actions/runs/10061834317/job/27812847663?pr=227