### PR TITLE
Setup default local proerties to make CI happy

### DIFF
--- a/local.defaults.properties
+++ b/local.defaults.properties
@@ -1,0 +1,6 @@
+# Example local.properties which can be checked into repo for CI
+# read more: https://github.com/google/secrets-gradle-plugin?tab=readme-ov-file#cicd-systems
+#
+# Afterpay merchant ID (not checked into version control)
+# Used by https://static-us.afterpay.com/javascript/button/index.html
+merchantId = "REPLACE"

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -57,3 +57,7 @@ dependencies {
     implementation(libs.androidxLifecycleRuntimeKtx)
     implementation(libs.material)
 }
+
+secrets {
+    defaultPropertiesFileName = "local.defaults.properties"
+}


### PR DESCRIPTION
Github actions is complaining about missing local.properties, as it should since it doesn't get commited to the repo. 

Gradle Secrets allows us to define a default file specifically for CI
https://github.com/google/secrets-gradle-plugin?tab=readme-ov-file#cicd-systems