### PR TITLE
Update workflow yaml

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -20,14 +20,17 @@ jobs:
           java-version: 11
           distribution: 'zulu'
 
+      - name: Build
+        run: ./gradlew afterpay:build
+
       - name: Lint
-        run: ./gradlew afterpay:lintDebug afterpay:ktlint
+        run: ./gradlew afterpay:lint afterpay:spotlessCheck
 
       - name: Unit Tests
         run: ./gradlew afterpay:testDebugUnitTest
 
   build-example:
-    name: Build Example Project
+    name: Build Sample Project
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
@@ -39,5 +42,8 @@ jobs:
           java-version: 11
           distribution: 'zulu'
 
-      - name: Build and Lint
-        run: ./gradlew example:buildDebug example:lintDebug example:ktlint
+      - name: Build
+        run: ./gradlew sample:buildDebug
+
+      - name: Lint
+        run: ./gradlew sample:lintDebug sample:spotlessCheck


### PR DESCRIPTION
This should now match master.\

For some reason feature/button is still trying to run `jobs` from master, but pointed to it's own yaml. Easiest thing to do is to just make base and feature branch identical


<img width="1219" alt="Screenshot 2024-07-25 at 10 15 16 PM" src="https://github.com/user-attachments/assets/fb17ef22-4799-4545-8747-326b7e63f959">

