### PR TITLE
Align various build tools with Cash App Pay Android SDK

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,10 +14,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Build
@@ -36,10 +36,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Build

--- a/.github/workflows/release-snapshot.yml
+++ b/.github/workflows/release-snapshot.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Clean repository before building SDK

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
       - name: Clone Repository
         uses: actions/checkout@v3
 
-      - name: Set up JDK 11
+      - name: Set up JDK 17
         uses: actions/setup-java@v2
         with:
-          java-version: 11
+          java-version: 17
           distribution: 'zulu'
 
       - name: Remove SNAPSHOT from version

--- a/afterpay/build.gradle.kts
+++ b/afterpay/build.gradle.kts
@@ -35,7 +35,6 @@ kotlin {
 
 android {
     compileSdk = libs.versions.compileSdkVersion.get().toInt()
-    buildToolsVersion = libs.versions.buildTools.get()
 
     defaultConfig {
         minSdk = libs.versions.minSdk.get().toInt()
@@ -47,6 +46,10 @@ android {
         consumerProguardFiles("consumer-rules.pro")
     }
 
+    buildFeatures {
+        buildConfig = true
+    }
+
     buildTypes {
         create("staging") {
             initWith(getByName("debug"))
@@ -55,8 +58,6 @@ android {
 
     compileOptions {
         isCoreLibraryDesugaringEnabled = true
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
     }
 
     namespace = "com.afterpay.android"

--- a/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentLocaleTest.kt
+++ b/afterpay/src/test/kotlin/com/afterpay/android/AfterpayInstalmentLocaleTest.kt
@@ -89,7 +89,7 @@ class AfterpayInstalmentLocaleTest {
         val instalments = createAllAvailableInstalments(oneHundredAndTwenty, Locales.FR_CA)
 
         assertEquals("$30,00 AUD", instalments.aud.instalmentAmount)
-        assertEquals("30,00 $", instalments.cad.instalmentAmount)
+        assertEquals("30,00 $ CA", instalments.cad.instalmentAmount)
         assertEquals("£30,00", instalments.gbp.instalmentAmount)
         assertEquals("$30,00 NZD", instalments.nzd.instalmentAmount)
         assertEquals("$30,00 USD", instalments.usd.instalmentAmount)
@@ -100,7 +100,7 @@ class AfterpayInstalmentLocaleTest {
         val instalments = createAllUnavailableInstalments(oneHundredAndTwenty, Locales.FR_CA)
 
         assertEquals("$10 AUD", instalments.aud.minimumAmount)
-        assertEquals("10 $", instalments.cad.minimumAmount)
+        assertEquals("10 $ CA", instalments.cad.minimumAmount)
         assertEquals("£10", instalments.gbp.minimumAmount)
         assertEquals("$10 NZD", instalments.nzd.minimumAmount)
         assertEquals("$10 USD", instalments.usd.minimumAmount)

--- a/gradle.properties
+++ b/gradle.properties
@@ -18,5 +18,3 @@ org.gradle.jvmargs=-Xmx2048m
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
-
-android.disableAutomaticComponentCreation=true

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,11 +1,10 @@
 [versions]
-compileSdkVersion = "31"
+compileSdkVersion = "33"
 exampleCompileSdk = "34"
 minSdk = "24"
-java = "11"
-buildTools = "30.0.3"
+java = "17" # remember to update java version in .github/workflows as well
 
-androidGradlePlugin = "7.4.2"
+androidGradlePlugin = "8.2.2"
 kotlin = "1.7.20"
 kotlinx_coroutines = "1.7.1"
 kotlinx_serialization = "1.5.1"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -20,7 +20,7 @@ mockk = "1.13.5"
 moshi = "1.14.0" # latest version that is compatible with kotlin 1.7.x
 retrofit = "2.9.0" # latest version that is compatible with kotlin 1.7.x
 secretsGradlePlugin = "2.0.1"
-tools_desugar_sdk = "1.1.5"
+tools_desugar_sdk = "2.1.2"
 
 [libraries]
 kotlinCoroutinesAndroid = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-android", version.ref = "kotlinx_coroutines" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-bin.zip

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.2-all.zip

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -35,15 +35,16 @@ android {
     namespace = "com.example"
 
     compileSdk = libs.versions.exampleCompileSdk.get().toInt()
-    buildToolsVersion = libs.versions.buildTools.get()
 
     buildFeatures {
+        buildConfig = true
         viewBinding = true
     }
+
     compileOptions {
-        sourceCompatibility = JavaVersion.VERSION_1_8
-        targetCompatibility = JavaVersion.VERSION_1_8
+        isCoreLibraryDesugaringEnabled = true
     }
+
     defaultConfig {
         applicationId = "com.afterpay.android.sample"
         minSdk = libs.versions.minSdk.get().toInt()
@@ -74,6 +75,8 @@ dependencies {
     implementation(libs.moshi.kotlin)
     implementation(libs.retrofit)
     implementation(libs.retrofit.converter.moshi)
+
+    coreLibraryDesugaring(libs.androidToolsDesugarJdk)
 }
 
 secrets {


### PR DESCRIPTION
We want to mirror the current build configuration of
Cash App Pay Android SDK. So:

* bump Android Gradle Plugin to 8.2.2
* bump Gradle to 8.2
* bump compile and target SDKs to 33
* Bump (and unify) java version to 17

++ we already depend on APIs from SDK 24, so I choose *not* to lower minSDK to 21 to match Cash App Pay SDK

As part of these bumps I also cleanup:
1. we no longer need to set buildToolsVersion.
	We haven't needed to set this since AGP 3.0.0 !!!
2. We don't need to set target/source compatibility.
	This is already handled by javaToolchain.
3. bump desugaring lib to support new Java language features
