### PR TITLE
Fix sample app / documentation bug related to brand ID

### DIFF
--- a/docs/getting-started/v3-with-cash-app-pay.md
+++ b/docs/getting-started/v3-with-cash-app-pay.md
@@ -169,11 +169,7 @@ fun createCashAppPayCustomerRequest(checkoutV3CashAppPay: CheckoutV3CashAppPay) 
     val action = CashAppPayPaymentAction.OneTimeAction(
         currency = USD,
         amount = // TODO transaction amount,
-	    /**
-         * This is not the same merchant ID you set in [CheckoutV3Configuration].
-         * This is a specific for use with Cash App Pay SDK.
-         */
-        scopeId = checkoutV3CashAppPay.merchantId,
+        scopeId = checkoutV3CashAppPay.brandId,
     )
 
     cashAppPay.createCustomerRequest(

--- a/sample/src/main/java/com/example/CashAppV3SampleActivity.kt
+++ b/sample/src/main/java/com/example/CashAppV3SampleActivity.kt
@@ -269,11 +269,7 @@ class CashAppV3SampleActivity : AppCompatActivity() {
         val action = CashAppPayPaymentAction.OneTimeAction(
             currency = USD,
             amount = checkoutV3CashAppPay.amount.toInt(),
-            /**
-             * This is not the same merchant ID you set in [CheckoutV3Configuration].
-             * This is a specific for use with Cash App Pay SDK.
-             */
-            scopeId = checkoutV3CashAppPay.merchantId,
+            scopeId = checkoutV3CashAppPay.brandId,
         )
 
         cashAppPay.createCustomerRequest(


### PR DESCRIPTION
We should pass brand ID not merchantID to scopeID

This just affects sample app and documentation. No release is needed for merchants to capture these changes.