### PR TITLE
Crash on invalid state in sandbox env

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -34,6 +34,7 @@ import android.widget.TextView
 import androidx.core.content.res.ResourcesCompat
 import androidx.core.content.res.use
 import com.afterpay.android.Afterpay
+import com.afterpay.android.AfterpayEnvironment.SANDBOX
 import com.afterpay.android.R
 import com.afterpay.android.internal.AfterpayInfoSpan
 import com.afterpay.android.internal.AfterpayInstalment
@@ -157,6 +158,9 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
   }
 
   private fun updateText() {
+    if (Afterpay.environment == SANDBOX && colorScheme.isCashAppScheme() && logoType != LOCKUP) {
+      throw IllegalStateException("Cannot use non-lockup logo types in US locale.\nNote: this will only throw an exception in sandbox environment, the view will be hidden if a non-lockup logo type is used in US locale in production.")
+    }
     visibility = if (!Afterpay.enabled || (colorScheme.isCashAppScheme() && logoType != LOCKUP)) View.GONE else View.VISIBLE
 
     val drawable: Drawable = generateLogo()

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayPriceBreakdown.kt
@@ -159,7 +159,11 @@ class AfterpayPriceBreakdown @JvmOverloads constructor(
 
   private fun updateText() {
     if (Afterpay.environment == SANDBOX && colorScheme.isCashAppScheme() && logoType != LOCKUP) {
-      throw IllegalStateException("Cannot use non-lockup logo types in US locale.\nNote: this will only throw an exception in sandbox environment, the view will be hidden if a non-lockup logo type is used in US locale in production.")
+      throw IllegalStateException(
+        "Cannot use non-lockup logo types in US locale.\nNote: this will" +
+          " only throw an exception in sandbox environment, the view will be hidden if a non-lockup " +
+          "logo type is used in US locale in production.",
+      )
     }
     visibility = if (!Afterpay.enabled || (colorScheme.isCashAppScheme() && logoType != LOCKUP)) View.GONE else View.VISIBLE
 

--- a/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
+++ b/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
@@ -21,7 +21,6 @@ import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.afterpay.android.Afterpay
 import com.afterpay.android.view.AfterpayLogoType
-import com.afterpay.android.view.AfterpayLogoType.LOCKUP
 import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.afterpay.android.view.AfterpayWidgetStyle
 import com.example.api.GetConfigurationResponse

--- a/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
+++ b/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
@@ -57,9 +57,7 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
             LinearLayout.LayoutParams.WRAP_CONTENT,
           )
           logoContainer.addView(breakdownView, params)
-        } catch (e: IllegalStateException) {
-          e.printStackTrace()
-        }
+        } catch (_: IllegalStateException) {}
       }
     }
 
@@ -80,7 +78,9 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
 
         onSuccess { response: GetConfigurationResponse ->
           withContext(Dispatchers.Main) {
-            // Configuration update will trigger another updateText so we need to catch exceptions here as well
+            // Not all logoTypes are valid in each locale (i.e. non-lockup types are not valid in
+            // US locale) so we catch exceptions here since an updateText call is triggered when
+            // configuration updates
             try {
               Afterpay.setConfiguration(
                 minimumAmount = response.minimumAmount?.amount,
@@ -90,9 +90,7 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
                 Locale(response.locale.language, response.locale.country),
                 environment = AFTERPAY_ENVIRONMENT,
               )
-            } catch (e: IllegalStateException) {
-              e.printStackTrace()
-            }
+            } catch (_: IllegalStateException) {}
           }
         }
       }


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes
<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Crash on invalid price breakdown view state (i.e. when local is US and non -lockup logo type selected) in sandbox environment.
- Prevent crashes in sample app for invalid configurations so that we can display all valid configurations in all locales 
