### PR TITLE
Explicitly set WebView settings' allowFileAccess to false

### DIFF
--- a/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/internal/AfterpayInfoActivity.kt
@@ -31,8 +31,10 @@ internal class AfterpayInfoActivity : AppCompatActivity() {
 
     window.setLayout(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT)
 
-    webView = findViewById<WebView>(R.id.afterpay_webView)
-      .setAfterpayUserAgentString()
+    webView = findViewById<WebView>(R.id.afterpay_webView).apply {
+      setAfterpayUserAgentString()
+      settings.allowFileAccess = false
+    }
 
     loadUrl()
   }

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutActivity.kt
@@ -65,6 +65,7 @@ internal class AfterpayCheckoutActivity : AppCompatActivity() {
 
     webView = findViewById<WebView>(R.id.afterpay_webView).apply {
       setAfterpayUserAgentString()
+      settings.allowFileAccess = false
       settings.javaScriptEnabled = true
       settings.setSupportMultipleWindows(true)
       settings.setDomStorageEnabled(true)

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV2Activity.kt
@@ -95,6 +95,7 @@ internal class AfterpayCheckoutV2Activity : AppCompatActivity() {
 
     bootstrapWebView.apply {
       setAfterpayUserAgentString()
+      settings.allowFileAccess = false
       settings.javaScriptEnabled = true
       settings.javaScriptCanOpenWindowsAutomatically = true
       settings.setSupportMultipleWindows(true)
@@ -254,6 +255,7 @@ private class BootstrapWebChromeClient(
     val webView = WebView(context)
     webView.setAfterpayUserAgentString()
     webView.visibility = INVISIBLE
+    webView.settings.allowFileAccess = false
     webView.settings.javaScriptEnabled = true
     webView.settings.setSupportMultipleWindows(true)
     webView.settings.domStorageEnabled = true

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV3Activity.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayCheckoutV3Activity.kt
@@ -59,6 +59,7 @@ internal class AfterpayCheckoutV3Activity : AppCompatActivity() {
     viewModel = CheckoutV3ViewModel(requireNotNull(intent.getCheckoutV3OptionsExtra()))
     webView = findViewById<WebView>(R.id.afterpay_webView).apply {
       setAfterpayUserAgentString()
+      settings.allowFileAccess = false
       settings.javaScriptEnabled = true
       settings.setSupportMultipleWindows(true)
       webViewClient = AfterpayWebViewClientV3(

--- a/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayWidgetView.kt
+++ b/afterpay/src/main/kotlin/com/afterpay/android/view/AfterpayWidgetView.kt
@@ -137,6 +137,7 @@ class AfterpayWidgetView @JvmOverloads constructor(
     onPageFinished: () -> Unit,
   ) {
     setAfterpayUserAgentString()
+    settings.allowFileAccess = false
     @SuppressLint("SetJavaScriptEnabled")
     settings.javaScriptEnabled = true
     settings.domStorageEnabled = true


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
- Explicitly set WebView settings' `allowFileAccess` to `false` to prevent possible security issues where apps could access local files through WebView.

