### PR TITLE
Update `actions/upload-pages-artifact` version to `v3`

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -31,7 +31,7 @@ jobs:
           source: ./docs
           destination: ./docs/_site
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: 'docs/_site'
 


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->
Documentation deployment is broken since 4.8.0 because `actions/upload-pages-artifact: v1` that we use to update docs to GitHub pages depends on `actions/upload-artifact: v3` which is deprecated. [Failing task](https://github.com/afterpay/sdk-android/actions/runs/13594688250)

This PR updates the `actions/upload-pages-artifact` to `v3` (which uses `actions/upload-artifact: v4`) to fix the deployment. [Release note](https://github.com/actions/upload-pages-artifact/releases/tag/v3.0.0)
<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->

<!--
Please remove items that do not apply and check off those that do.
-->
