### PR TITLE
Update actions/deploy-pages version to v4

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -45,4 +45,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v2
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
<!--
Thank you for your pull request. Please provide a concise description, summary
of the changes and review the requirements below. Make sure to label the request
appropriately.

Bug fixes and new features should include tests and documentation.

Contributors guide: https://github.com/afterpay/sdk-android/blob/master/CONTRIBUTING.md
-->

## Summary of Changes

<!--
Please list a brief summary of the changes and links to any resolved issues.
-->

#274 fixed the `build` step of `Deploy Docs with GitHub Pages dependencies preinstalled`, but the `deploy` is still failing. 
This PR updates the `actions/deploy-pages` version to `v4` as it's compatible with `actions/upload-pages-artifact: v3` to fix the deployment issue.

<!--
Document anything here that you think the reviewers of this PR may need to
know, or would be of specific interest.
-->


<!--
Please remove items that do not apply and check off those that do.
-->

