### PR TITLE
Improve Example app Widget's UI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -118,3 +118,5 @@ docs/_site
 
 !/gradle/wrapper/gradle-wrapper.jar
 /.idea/AndroidProjectSystem.xml
+/.claude
+CLAUDE.md

--- a/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
+++ b/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
@@ -98,7 +98,7 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
         }
         container.addView(captionView, captionParams)
       } catch (_: IllegalStateException) {
-        // Some configurations are not valid in certain locales
+        // For example, in US locale (Cash App scheme) logoType = BADGE or COMPACT_BADGE is invalid; only LOCKUP is allowed.
       }
     }
 

--- a/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
+++ b/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
@@ -21,6 +21,7 @@ import android.util.TypedValue
 import android.widget.LinearLayout
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
+import androidx.core.content.ContextCompat
 import androidx.lifecycle.lifecycleScope
 import com.afterpay.android.Afterpay
 import com.afterpay.android.view.AfterpayIntroText
@@ -35,6 +36,7 @@ import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 import java.math.BigDecimal
 import java.util.Locale
+import kotlin.math.roundToInt
 
 class AfterpayUiGalleryActivity : AppCompatActivity() {
 
@@ -57,8 +59,14 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
   }
 
   private fun populatePriceBreakdowns(container: LinearLayout, isDarkBackground: Boolean) {
-    val captionColor = if (isDarkBackground) 0xFF999999.toInt() else 0xFF666666.toInt()
-    val labelColor = if (isDarkBackground) 0xFFCCCCCC.toInt() else 0xFF333333.toInt()
+    val captionColor = ContextCompat.getColor(
+      this,
+      if (isDarkBackground) R.color.ui_gallery_caption_dark else R.color.ui_gallery_caption_light,
+    )
+    val labelColor = ContextCompat.getColor(
+      this,
+      if (isDarkBackground) R.color.ui_gallery_label_dark else R.color.ui_gallery_label_light,
+    )
 
     // Helper to add a price breakdown with caption
     fun addPriceBreakdown(
@@ -85,8 +93,8 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
           LinearLayout.LayoutParams.WRAP_CONTENT,
           LinearLayout.LayoutParams.WRAP_CONTENT,
         ).apply {
-          topMargin = (4 * resources.displayMetrics.density).toInt()
-          bottomMargin = (20 * resources.displayMetrics.density).toInt()
+          topMargin = (4 * resources.displayMetrics.density).roundToInt()
+          bottomMargin = (20 * resources.displayMetrics.density).roundToInt()
         }
         container.addView(captionView, captionParams)
       } catch (_: IllegalStateException) {
@@ -106,8 +114,8 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
         LinearLayout.LayoutParams.WRAP_CONTENT,
         LinearLayout.LayoutParams.WRAP_CONTENT,
       ).apply {
-        topMargin = (16 * resources.displayMetrics.density).toInt()
-        bottomMargin = (12 * resources.displayMetrics.density).toInt()
+        topMargin = (16 * resources.displayMetrics.density).roundToInt()
+        bottomMargin = (12 * resources.displayMetrics.density).roundToInt()
       }
       container.addView(labelView, labelParams)
     }
@@ -192,8 +200,8 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
         LinearLayout.LayoutParams.WRAP_CONTENT,
         LinearLayout.LayoutParams.WRAP_CONTENT,
       ).apply {
-        topMargin = (4 * resources.displayMetrics.density).toInt()
-        bottomMargin = (20 * resources.displayMetrics.density).toInt()
+        topMargin = (4 * resources.displayMetrics.density).roundToInt()
+        bottomMargin = (20 * resources.displayMetrics.density).roundToInt()
       }
       container.addView(captionView, captionParams)
     } catch (_: IllegalStateException) {}

--- a/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
+++ b/sample/src/main/java/com/example/AfterpayUiGalleryActivity.kt
@@ -15,11 +15,15 @@
  */
 package com.example
 
+import android.graphics.Typeface
 import android.os.Bundle
+import android.util.TypedValue
 import android.widget.LinearLayout
+import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import com.afterpay.android.Afterpay
+import com.afterpay.android.view.AfterpayIntroText
 import com.afterpay.android.view.AfterpayLogoType
 import com.afterpay.android.view.AfterpayPriceBreakdown
 import com.afterpay.android.view.AfterpayWidgetStyle
@@ -38,28 +42,12 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.afterpay_ui_widgets)
 
-    val logoContainer = findViewById<LinearLayout>(R.id.logo_container)
+    val darkContainer = findViewById<LinearLayout>(R.id.price_breakdown_container_dark)
+    val lightContainer = findViewById<LinearLayout>(R.id.price_breakdown_container_light)
 
-    // Instantiate an AfterpayPriceBreakdown and fill it with dummy info.
-    AfterpayLogoType.values().forEach { logoType ->
-
-      AfterpayWidgetStyle.values().forEach { style ->
-        try {
-          // Not all logoTypes are valid in each locale (i.e. non-lockup types are not valid in US locale)
-          // so we catch exceptions here
-          val breakdownView = AfterpayPriceBreakdown(this).apply {
-            totalAmount = BigDecimal("100.00")
-            this.logoType = logoType
-            this.style = style
-          }
-          val params = LinearLayout.LayoutParams(
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-            LinearLayout.LayoutParams.WRAP_CONTENT,
-          )
-          logoContainer.addView(breakdownView, params)
-        } catch (_: IllegalStateException) {}
-      }
-    }
+    // Populate both containers with price breakdown widgets
+    populatePriceBreakdowns(darkContainer, isDarkBackground = true)
+    populatePriceBreakdowns(lightContainer, isDarkBackground = false)
 
     // This is needed so that the UI gets inflated.
     // Right now an AP server needs to for the UI to be inflated.
@@ -68,10 +56,172 @@ class AfterpayUiGalleryActivity : AppCompatActivity() {
     }
   }
 
+  private fun populatePriceBreakdowns(container: LinearLayout, isDarkBackground: Boolean) {
+    val captionColor = if (isDarkBackground) 0xFF999999.toInt() else 0xFF666666.toInt()
+    val labelColor = if (isDarkBackground) 0xFFCCCCCC.toInt() else 0xFF333333.toInt()
+
+    // Helper to add a price breakdown with caption
+    fun addPriceBreakdown(
+      caption: String,
+      configure: AfterpayPriceBreakdown.() -> Unit,
+    ) {
+      try {
+        val breakdownView = AfterpayPriceBreakdown(this).apply {
+          totalAmount = BigDecimal("100.00")
+          configure()
+        }
+        val breakdownParams = LinearLayout.LayoutParams(
+          LinearLayout.LayoutParams.WRAP_CONTENT,
+          LinearLayout.LayoutParams.WRAP_CONTENT,
+        )
+        container.addView(breakdownView, breakdownParams)
+
+        val captionView = TextView(this).apply {
+          text = caption
+          setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+          setTextColor(captionColor)
+        }
+        val captionParams = LinearLayout.LayoutParams(
+          LinearLayout.LayoutParams.WRAP_CONTENT,
+          LinearLayout.LayoutParams.WRAP_CONTENT,
+        ).apply {
+          topMargin = (4 * resources.displayMetrics.density).toInt()
+          bottomMargin = (20 * resources.displayMetrics.density).toInt()
+        }
+        container.addView(captionView, captionParams)
+      } catch (_: IllegalStateException) {
+        // Some configurations are not valid in certain locales
+      }
+    }
+
+    // Helper to add a section divider with label
+    fun addSectionLabel(label: String) {
+      val labelView = TextView(this).apply {
+        text = label
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, 14f)
+        setTextColor(labelColor)
+        setTypeface(typeface, Typeface.BOLD)
+      }
+      val labelParams = LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+      ).apply {
+        topMargin = (16 * resources.displayMetrics.density).toInt()
+        bottomMargin = (12 * resources.displayMetrics.density).toInt()
+      }
+      container.addView(labelView, labelParams)
+    }
+
+    // ===== Logo type variations =====
+    addSectionLabel("Logo type variations")
+
+    addPriceBreakdown("logoType: badge") {
+      logoType = AfterpayLogoType.BADGE
+    }
+
+    addPriceBreakdown("logoType: lockup") {
+      logoType = AfterpayLogoType.LOCKUP
+    }
+
+    addPriceBreakdown("logoType: compactBadge") {
+      logoType = AfterpayLogoType.COMPACT_BADGE
+    }
+
+    // ===== Intro text variations =====
+    addSectionLabel("Intro text variations")
+
+    addPriceBreakdown("introText: or") {
+      introText = AfterpayIntroText.OR
+    }
+
+    addPriceBreakdown("introText: payIn") {
+      introText = AfterpayIntroText.PAY_IN
+    }
+
+    addPriceBreakdown("introText: make") {
+      introText = AfterpayIntroText.MAKE
+    }
+
+    addPriceBreakdown("introText: pay") {
+      introText = AfterpayIntroText.PAY
+    }
+
+    addPriceBreakdown("introText: in") {
+      introText = AfterpayIntroText.IN
+    }
+
+    addPriceBreakdown("introText: empty") {
+      introText = AfterpayIntroText.EMPTY
+    }
+
+    // ===== Display options =====
+    addSectionLabel("Display options")
+
+    addPriceBreakdown("showWithText: false") {
+      showWithText = false
+    }
+
+    addPriceBreakdown("showInterestFreeText: false") {
+      showInterestFreeText = false
+    }
+
+    addPriceBreakdown("minimal (no with/interest)") {
+      showWithText = false
+      showInterestFreeText = false
+    }
+
+    // ===== Amount edge case =====
+    addSectionLabel("Amount edge cases")
+
+    try {
+      val outOfRangeView = AfterpayPriceBreakdown(this).apply {
+        totalAmount = BigDecimal("10000000.00") // Out of range amount
+      }
+      val breakdownParams = LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+      )
+      container.addView(outOfRangeView, breakdownParams)
+
+      val captionView = TextView(this).apply {
+        text = "amount out of range"
+        setTextSize(TypedValue.COMPLEX_UNIT_SP, 12f)
+        setTextColor(captionColor)
+      }
+      val captionParams = LinearLayout.LayoutParams(
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+        LinearLayout.LayoutParams.WRAP_CONTENT,
+      ).apply {
+        topMargin = (4 * resources.displayMetrics.density).toInt()
+        bottomMargin = (20 * resources.displayMetrics.density).toInt()
+      }
+      container.addView(captionView, captionParams)
+    } catch (_: IllegalStateException) {}
+
+    // ===== Logo color schemes =====
+    addSectionLabel("Logo color schemes")
+
+    addPriceBreakdown("style: default") {
+      style = AfterpayWidgetStyle.Default
+    }
+
+    addPriceBreakdown("style: alt") {
+      style = AfterpayWidgetStyle.Alt
+    }
+
+    addPriceBreakdown("style: monochromeDark") {
+      style = AfterpayWidgetStyle.MonochromeDark
+    }
+
+    addPriceBreakdown("style: monochromeLight") {
+      style = AfterpayWidgetStyle.MonochromeLight
+    }
+  }
+
   private fun getConfiguration() {
     CoroutineScope(Dispatchers.IO).launch {
       merchantApi().getConfiguration().apply {
-        onFailure { error ->
+        onFailure { _ ->
           val msg = "You must run an AP server to fetch configuration."
           showToastFromBackground(this@AfterpayUiGalleryActivity, msg)
         }

--- a/sample/src/main/res/layout/afterpay_ui_widgets.xml
+++ b/sample/src/main/res/layout/afterpay_ui_widgets.xml
@@ -9,243 +9,884 @@
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:orientation="vertical">
+
+    <!-- ==================== DARK BACKGROUND SECTION ==================== -->
     <LinearLayout
-      android:id="@+id/logo_lockups_container"
+      android:id="@+id/dark_section"
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical"
-      android:padding="16dp">
-      <!-- Section Header Badge and Lockup -->
+      android:background="#1A1A1A">
+
+      <!-- Section Header -->
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="Dark Background"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF" />
+
+      <!-- ===== BADGE SECTION ===== -->
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="8dp"
+          android:text="AfterpayBadge"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          android:textColor="#FFFFFF" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          afterpay:afterpayStyle="default_style"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · default"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="alt"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · alt"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeDark"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeLight"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+      </LinearLayout>
+
+      <!-- Divider -->
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="#333333" />
+
+      <!-- ===== LOCKUP SECTION ===== -->
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="8dp"
+          android:text="AfterpayLockup"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          android:textColor="#FFFFFF" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          afterpay:afterpayStyle="default_style"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · default"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="alt"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · alt"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeDark"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeLight"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+      </LinearLayout>
+
+      <!-- Divider -->
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="#333333" />
+
+      <!-- ===== PAYMENT BUTTON SECTION ===== -->
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="8dp"
+          android:text="AfterpayPaymentButton"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          android:textColor="#FFFFFF" />
+
+        <!-- buyNow variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · default"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · alt"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <!-- checkout variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · default"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · alt"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <!-- payNow variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · default"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · alt"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <!-- placeOrder variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · placeOrder · default"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · placeOrder · alt"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · placeOrder · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayPaymentButton · placeOrder · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#999999" />
+      </LinearLayout>
+
+      <!-- Divider -->
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="#333333" />
+
+      <!-- ===== PRICE BREAKDOWN SECTION (dynamically generated) ===== -->
       <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_marginBottom="8dp"
-        android:text="AP Badge and Lockup"
+        android:text="AfterpayPriceBreakdown"
         android:textSize="18sp"
-        android:textStyle="bold" />
+        android:paddingHorizontal="16dp"
+        android:textStyle="bold"
+        android:textColor="#FFFFFF" />
 
-      <com.afterpay.android.view.AfterpayBadge
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        afterpay:afterpayStyle="default_style"/>
-
-      <com.afterpay.android.view.AfterpayLockup
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        afterpay:afterpayStyle="default_style"/>
-
-      <com.afterpay.android.view.AfterpayLockup
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        afterpay:afterpayStyle="alt"/>
-
-      <com.afterpay.android.view.AfterpayLockup
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        afterpay:afterpayStyle="monochromeLight"/>
-
-      <com.afterpay.android.view.AfterpayLockup
-        android:layout_width="wrap_content"
-        android:layout_height="wrap_content"
-        android:layout_marginTop="10dp"
-        afterpay:afterpayStyle="monochromeDark"/>
-    </LinearLayout>
-
-    <!-- Divider -->
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:layout_marginVertical="16dp"
-      android:padding="16dp"
-      android:background="#CCCCCC" />
-
-    <!-- Section Header for Logo Types -->
-    <TextView
-      android:layout_width="wrap_content"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="8dp"
-      android:text="Afterpay Price breakdown"
-      android:textSize="18sp"
-      android:paddingHorizontal="16dp"
-      android:textStyle="bold" />
-
-    <!-- Container for programmatically inflated widget -->
-    <LinearLayout
-      android:id="@+id/logo_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      android:padding="16dp"/>
-
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:layout_marginVertical="16dp"
-      android:padding="16dp"
-      android:background="#CCCCCC" />
-
-    <LinearLayout
-      android:id="@+id/button_container"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:orientation="vertical"
-      android:padding="16dp">
-    <!-- Payment Buttons Section -->
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_default_button_pay_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="payNow"
-      afterpay:afterpayStyle="default_style" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_default_button_buy_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="buyNow"
-      afterpay:afterpayStyle="default_style" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_default_button_checkout_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="checkout"
-      afterpay:afterpayStyle="default_style" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_default_button_continue_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      afterpay:afterpayButtonText="placeOrder"
-      afterpay:afterpayStyle="default_style" />
-
-    <!-- Divider -->
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:layout_marginVertical="16dp"
-      android:background="#CCCCCC" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_alt_pay_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="payNow"
-      afterpay:afterpayStyle="alt" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_alt_buy_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="buyNow"
-      afterpay:afterpayStyle="alt" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_alt_checkout_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="checkout"
-      afterpay:afterpayStyle="alt" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_alt_continue_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      afterpay:afterpayButtonText="placeOrder"
-      afterpay:afterpayStyle="alt" />
-
-    <!-- Divider -->
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:layout_marginVertical="16dp"
-      android:background="#CCCCCC" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_monochrome_dark_pay_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="payNow"
-      afterpay:afterpayStyle="monochromeDark" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_monochrome_dark_buy_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="buyNow"
-      afterpay:afterpayStyle="monochromeDark" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_monochrome_dark_checkout_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="checkout"
-      afterpay:afterpayStyle="monochromeDark" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_monochrome_dark_continue_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      afterpay:afterpayButtonText="placeOrder"
-      afterpay:afterpayStyle="monochromeDark" />
-
-    <!-- Divider -->
-    <View
-      android:layout_width="match_parent"
-      android:layout_height="1dp"
-      android:layout_marginVertical="16dp"
-      android:background="#CCCCCC" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_monochrome_light_pay_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      android:layout_marginBottom="16dp"
-      afterpay:afterpayButtonText="payNow"
-      afterpay:afterpayStyle="monochromeLight" />
-
-    <com.afterpay.android.view.AfterpayPaymentButton
-      android:id="@+id/afterpay_cash_app_button_monochrome_light_buy_now"
-      android:layout_width="match_parent"
-      android:layout_height="wrap_content"
-      afterpay:afterpayButtonText="buyNow"
-      afterpay:afterpayStyle="monochromeLight" />
-  </LinearLayout>
-
-    <LinearLayout
-        android:id="@+id/monochrome_light_on_light_button_container"
+      <LinearLayout
+        android:id="@+id/price_breakdown_container_dark"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:orientation="vertical"
-        android:padding="16dp"
-        android:background="@android:color/white">
+        android:padding="16dp"/>
+
+    </LinearLayout>
+
+    <!-- ==================== LIGHT BACKGROUND SECTION ==================== -->
+    <LinearLayout
+      android:id="@+id/light_section"
+      android:layout_width="match_parent"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      android:background="#FFFFFF">
+
+      <!-- Section Header -->
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_margin="16dp"
+        android:text="Light Background"
+        android:textSize="22sp"
+        android:textStyle="bold"
+        android:textColor="#000000" />
+
+      <!-- ===== BADGE SECTION ===== -->
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="8dp"
+          android:text="AfterpayBadge"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          android:textColor="#000000" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          afterpay:afterpayStyle="default_style"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · default"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="alt"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · alt"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeDark"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayBadge
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeLight"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayBadge · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+      </LinearLayout>
+
+      <!-- Divider -->
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="#CCCCCC" />
+
+      <!-- ===== LOCKUP SECTION ===== -->
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="8dp"
+          android:text="AfterpayLockup"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          android:textColor="#000000" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          afterpay:afterpayStyle="default_style"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · default"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="alt"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · alt"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeDark"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayLockup
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="14dp"
+          afterpay:afterpayStyle="monochromeLight"/>
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayLockup · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+      </LinearLayout>
+
+      <!-- Divider -->
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="#CCCCCC" />
+
+      <!-- ===== PAYMENT BUTTON SECTION ===== -->
+      <LinearLayout
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp">
+
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginBottom="8dp"
+          android:text="AfterpayPaymentButton"
+          android:textSize="18sp"
+          android:textStyle="bold"
+          android:textColor="#000000" />
+
+        <!-- buyNow variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
-          android:id="@+id/afterpay_cash_app_button_monochrome_light_checkout_now"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="16dp"
-          afterpay:afterpayButtonText="checkout"
-          afterpay:afterpayStyle="monochromeLight" />
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · default"
+          android:textSize="12sp"
+          android:textColor="#666666" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
-          android:id="@+id/afterpay_cash_app_button_monochrome_light_continue_now"
           android:layout_width="match_parent"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="16dp"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · alt"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="buyNow"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · buyNow · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <!-- checkout variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · default"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · alt"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="checkout"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · checkout · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <!-- payNow variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · default"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · alt"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="payNow"
+          afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · payNow · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <!-- placeOrder variants -->
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="default_style" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · placeOrder · default"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="alt" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · placeOrder · alt"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
+          afterpay:afterpayButtonText="placeOrder"
+          afterpay:afterpayStyle="monochromeDark" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:layout_marginBottom="20dp"
+          android:text="AfterpayPaymentButton · placeOrder · monochromeDark"
+          android:textSize="12sp"
+          android:textColor="#666666" />
+
+        <com.afterpay.android.view.AfterpayPaymentButton
+          android:layout_width="match_parent"
+          android:layout_height="wrap_content"
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="monochromeLight" />
+        <TextView
+          android:layout_width="wrap_content"
+          android:layout_height="wrap_content"
+          android:layout_marginTop="4dp"
+          android:text="AfterpayPaymentButton · placeOrder · monochromeLight"
+          android:textSize="12sp"
+          android:textColor="#666666" />
       </LinearLayout>
+
+      <!-- Divider -->
+      <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginVertical="16dp"
+        android:background="#CCCCCC" />
+
+      <!-- ===== PRICE BREAKDOWN SECTION (dynamically generated) ===== -->
+      <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginBottom="8dp"
+        android:text="AfterpayPriceBreakdown"
+        android:textSize="18sp"
+        android:paddingHorizontal="16dp"
+        android:textStyle="bold"
+        android:textColor="#000000" />
+
+      <LinearLayout
+        android:id="@+id/price_breakdown_container_light"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:padding="16dp"/>
+
+    </LinearLayout>
+
   </LinearLayout>
 </ScrollView>

--- a/sample/src/main/res/layout/afterpay_ui_widgets.xml
+++ b/sample/src/main/res/layout/afterpay_ui_widgets.xml
@@ -16,17 +16,14 @@
       android:layout_width="match_parent"
       android:layout_height="wrap_content"
       android:orientation="vertical"
-      android:background="#1A1A1A">
+      android:background="@color/ui_gallery_dark_bg">
 
       <!-- Section Header -->
       <TextView
+        style="@style/SectionHeader.Dark"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:text="Dark Background"
-        android:textSize="22sp"
-        android:textStyle="bold"
-        android:textColor="#FFFFFF" />
+        android:text="Dark Background" />
 
       <!-- ===== BADGE SECTION ===== -->
       <LinearLayout
@@ -36,25 +33,20 @@
         android:padding="16dp">
 
         <TextView
+          style="@style/WidgetHeader.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:text="AfterpayBadge"
-          android:textSize="18sp"
-          android:textStyle="bold"
-          android:textColor="#FFFFFF" />
+          android:text="AfterpayBadge" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           afterpay:afterpayStyle="default_style"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · default"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayBadge · default" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
@@ -62,12 +54,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="alt"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · alt"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayBadge · alt" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
@@ -75,12 +65,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeDark"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayBadge · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
@@ -88,12 +76,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeLight"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayBadge · monochromeLight" />
       </LinearLayout>
 
       <!-- Divider -->
@@ -101,7 +87,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginVertical="16dp"
-        android:background="#333333" />
+        android:background="@color/ui_gallery_divider_dark" />
 
       <!-- ===== LOCKUP SECTION ===== -->
       <LinearLayout
@@ -111,25 +97,20 @@
         android:padding="16dp">
 
         <TextView
+          style="@style/WidgetHeader.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:text="AfterpayLockup"
-          android:textSize="18sp"
-          android:textStyle="bold"
-          android:textColor="#FFFFFF" />
+          android:text="AfterpayLockup" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           afterpay:afterpayStyle="default_style"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · default"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayLockup · default" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
@@ -137,12 +118,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="alt"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · alt"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayLockup · alt" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
@@ -150,12 +129,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeDark"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayLockup · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
@@ -163,12 +140,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeLight"/>
         <TextView
+          style="@style/WidgetCaption.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayLockup · monochromeLight" />
       </LinearLayout>
 
       <!-- Divider -->
@@ -176,7 +151,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginVertical="16dp"
-        android:background="#333333" />
+        android:background="@color/ui_gallery_divider_dark" />
 
       <!-- ===== PAYMENT BUTTON SECTION ===== -->
       <LinearLayout
@@ -186,13 +161,10 @@
         android:padding="16dp">
 
         <TextView
+          style="@style/WidgetHeader.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:text="AfterpayPaymentButton"
-          android:textSize="18sp"
-          android:textStyle="bold"
-          android:textColor="#FFFFFF" />
+          android:text="AfterpayPaymentButton" />
 
         <!-- buyNow variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -201,13 +173,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · default"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · buyNow · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -215,13 +184,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · alt"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · buyNow · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -229,13 +195,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · buyNow · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -243,13 +206,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · buyNow · monochromeLight" />
 
         <!-- checkout variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -258,13 +218,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · default"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · checkout · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -272,13 +229,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · alt"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · checkout · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -286,13 +240,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · checkout · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -300,13 +251,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · checkout · monochromeLight" />
 
         <!-- payNow variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -315,13 +263,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · default"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · payNow · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -329,13 +274,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · alt"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · payNow · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -343,13 +285,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · payNow · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -357,13 +296,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · payNow · monochromeLight" />
 
         <!-- placeOrder variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -372,13 +308,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · placeOrder · default"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · placeOrder · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -386,13 +319,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · placeOrder · alt"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · placeOrder · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -400,13 +330,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · placeOrder · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · placeOrder · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -414,12 +341,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Dark"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayPaymentButton · placeOrder · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#999999" />
+          android:text="AfterpayPaymentButton · placeOrder · monochromeLight" />
       </LinearLayout>
 
       <!-- Divider -->
@@ -427,7 +352,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginVertical="16dp"
-        android:background="#333333" />
+        android:background="@color/ui_gallery_divider_dark" />
 
       <!-- ===== PRICE BREAKDOWN SECTION (dynamically generated) ===== -->
       <TextView
@@ -459,13 +384,10 @@
 
       <!-- Section Header -->
       <TextView
+        style="@style/SectionHeader.Light"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp"
-        android:text="Light Background"
-        android:textSize="22sp"
-        android:textStyle="bold"
-        android:textColor="#000000" />
+        android:text="Light Background" />
 
       <!-- ===== BADGE SECTION ===== -->
       <LinearLayout
@@ -475,25 +397,20 @@
         android:padding="16dp">
 
         <TextView
+          style="@style/WidgetHeader.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:text="AfterpayBadge"
-          android:textSize="18sp"
-          android:textStyle="bold"
-          android:textColor="#000000" />
+          android:text="AfterpayBadge" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           afterpay:afterpayStyle="default_style"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · default"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayBadge · default" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
@@ -501,12 +418,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="alt"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · alt"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayBadge · alt" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
@@ -514,12 +429,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeDark"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayBadge · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayBadge
           android:layout_width="wrap_content"
@@ -527,12 +440,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeLight"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayBadge · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayBadge · monochromeLight" />
       </LinearLayout>
 
       <!-- Divider -->
@@ -540,7 +451,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginVertical="16dp"
-        android:background="#CCCCCC" />
+        android:background="@color/ui_gallery_divider_light" />
 
       <!-- ===== LOCKUP SECTION ===== -->
       <LinearLayout
@@ -550,25 +461,20 @@
         android:padding="16dp">
 
         <TextView
+          style="@style/WidgetHeader.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:text="AfterpayLockup"
-          android:textSize="18sp"
-          android:textStyle="bold"
-          android:textColor="#000000" />
+          android:text="AfterpayLockup" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
           afterpay:afterpayStyle="default_style"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · default"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayLockup · default" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
@@ -576,12 +482,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="alt"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · alt"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayLockup · alt" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
@@ -589,12 +493,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeDark"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayLockup · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayLockup
           android:layout_width="wrap_content"
@@ -602,12 +504,10 @@
           android:layout_marginTop="14dp"
           afterpay:afterpayStyle="monochromeLight"/>
         <TextView
+          style="@style/WidgetCaption.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayLockup · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayLockup · monochromeLight" />
       </LinearLayout>
 
       <!-- Divider -->
@@ -615,7 +515,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginVertical="16dp"
-        android:background="#CCCCCC" />
+        android:background="@color/ui_gallery_divider_light" />
 
       <!-- ===== PAYMENT BUTTON SECTION ===== -->
       <LinearLayout
@@ -625,13 +525,10 @@
         android:padding="16dp">
 
         <TextView
+          style="@style/WidgetHeader.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginBottom="8dp"
-          android:text="AfterpayPaymentButton"
-          android:textSize="18sp"
-          android:textStyle="bold"
-          android:textColor="#000000" />
+          android:text="AfterpayPaymentButton" />
 
         <!-- buyNow variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -640,13 +537,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · default"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · buyNow · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -654,13 +548,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · alt"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · buyNow · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -668,13 +559,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · buyNow · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -682,13 +570,10 @@
           afterpay:afterpayButtonText="buyNow"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · buyNow · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · buyNow · monochromeLight" />
 
         <!-- checkout variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -697,13 +582,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · default"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · checkout · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -711,13 +593,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · alt"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · checkout · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -725,13 +604,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · checkout · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -739,13 +615,10 @@
           afterpay:afterpayButtonText="checkout"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · checkout · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · checkout · monochromeLight" />
 
         <!-- payNow variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -754,13 +627,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · default"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · payNow · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -768,13 +638,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · alt"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · payNow · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -782,13 +649,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · payNow · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -796,13 +660,10 @@
           afterpay:afterpayButtonText="payNow"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · payNow · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · payNow · monochromeLight" />
 
         <!-- placeOrder variants -->
         <com.afterpay.android.view.AfterpayPaymentButton
@@ -811,13 +672,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="default_style" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · placeOrder · default"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · placeOrder · default" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -825,13 +683,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="alt" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · placeOrder · alt"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · placeOrder · alt" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -839,13 +694,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="monochromeDark" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:layout_marginBottom="20dp"
-          android:text="AfterpayPaymentButton · placeOrder · monochromeDark"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · placeOrder · monochromeDark" />
 
         <com.afterpay.android.view.AfterpayPaymentButton
           android:layout_width="match_parent"
@@ -853,12 +705,10 @@
           afterpay:afterpayButtonText="placeOrder"
           afterpay:afterpayStyle="monochromeLight" />
         <TextView
+          style="@style/WidgetCaptionWithBottomMargin.Light"
           android:layout_width="wrap_content"
           android:layout_height="wrap_content"
-          android:layout_marginTop="4dp"
-          android:text="AfterpayPaymentButton · placeOrder · monochromeLight"
-          android:textSize="12sp"
-          android:textColor="#666666" />
+          android:text="AfterpayPaymentButton · placeOrder · monochromeLight" />
       </LinearLayout>
 
       <!-- Divider -->
@@ -866,7 +716,7 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_marginVertical="16dp"
-        android:background="#CCCCCC" />
+        android:background="@color/ui_gallery_divider_light" />
 
       <!-- ===== PRICE BREAKDOWN SECTION (dynamically generated) ===== -->
       <TextView

--- a/sample/src/main/res/values/colors.xml
+++ b/sample/src/main/res/values/colors.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- UI Gallery caption colors -->
+  <color name="ui_gallery_caption_dark">#999999</color>
+  <color name="ui_gallery_caption_light">#666666</color>
+  <color name="ui_gallery_label_dark">#CCCCCC</color>
+  <color name="ui_gallery_label_light">#333333</color>
+
+  <!-- UI Gallery section backgrounds -->
+  <color name="ui_gallery_dark_bg">#1A1A1A</color>
+  <color name="ui_gallery_divider_dark">#333333</color>
+  <color name="ui_gallery_divider_light">#CCCCCC</color>
+</resources>

--- a/sample/src/main/res/values/styles.xml
+++ b/sample/src/main/res/values/styles.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+  <!-- Base text appearance styles -->
+  <style name="WidgetCaption">
+    <item name="android:textSize">12sp</item>
+    <item name="android:layout_marginTop">4dp</item>
+  </style>
+
+  <style name="WidgetCaption.Dark">
+    <item name="android:textColor">@color/ui_gallery_caption_dark</item>
+  </style>
+
+  <style name="WidgetCaption.Light">
+    <item name="android:textColor">@color/ui_gallery_caption_light</item>
+  </style>
+
+  <style name="WidgetCaptionWithBottomMargin" parent="WidgetCaption">
+    <item name="android:layout_marginBottom">20dp</item>
+  </style>
+
+  <style name="WidgetCaptionWithBottomMargin.Dark">
+    <item name="android:textColor">@color/ui_gallery_caption_dark</item>
+  </style>
+
+  <style name="WidgetCaptionWithBottomMargin.Light">
+    <item name="android:textColor">@color/ui_gallery_caption_light</item>
+  </style>
+
+  <style name="WidgetHeader">
+    <item name="android:textSize">18sp</item>
+    <item name="android:textStyle">bold</item>
+    <item name="android:layout_marginBottom">8dp</item>
+  </style>
+
+  <style name="WidgetHeader.Dark">
+    <item name="android:textColor">#FFFFFF</item>
+  </style>
+
+  <style name="WidgetHeader.Light">
+    <item name="android:textColor">#000000</item>
+  </style>
+
+  <style name="SectionHeader">
+    <item name="android:textSize">22sp</item>
+    <item name="android:textStyle">bold</item>
+    <item name="android:layout_margin">16dp</item>
+  </style>
+
+  <style name="SectionHeader.Dark">
+    <item name="android:textColor">#FFFFFF</item>
+  </style>
+
+  <style name="SectionHeader.Light">
+    <item name="android:textColor">#000000</item>
+  </style>
+</resources>


### PR DESCRIPTION
# What

Improve the existing Widget's UI screen within the Example app:
* Now features full array of widget/configuration
* Match that of iOS (separate PR) for easier comparison between the two
* Labels describing each component's name + style

# Proof


https://github.com/user-attachments/assets/3f31c2e4-9a69-4795-b0c8-b0b90c230a8f

